### PR TITLE
Stateful IntToBits Conversion

### DIFF
--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -1381,6 +1381,7 @@ let dis_decode_entry (env: Eval.Env.t) (decode: decode_case) (op: value): stmt l
     let ((),lenv',stmts) = (dis_decode_case loc decode op) env lenv in
     let stmts' = Transforms.RemoveUnused.remove_unused globals @@ stmts in
     (* let stmts' = Transforms.Bits.bitvec_conversion stmts' in *)
+    let stmts' = Transforms.StatefulIntToBits.run stmts' in
     let stmts' = Transforms.IntToBits.ints_to_bits stmts' in
     let stmts' = Transforms.CommonSubExprElim.do_transform stmts' in
 

--- a/libASL/transforms.ml
+++ b/libASL/transforms.ml
@@ -1225,11 +1225,8 @@ module CommonSubExprElim = struct
       | "round_tozero_real"  -> type_integer
       | "round_down_real"    -> type_integer
       | "round_up_real"      -> type_integer
-      | "cvt_bits_sint"      -> type_integer
       | "in_mask"            -> type_bool
       | "notin_mask"         -> type_bool
-      | "eq_bits"            -> type_bool
-      | "ne_bits"            -> type_bool
       | "eq_str"             -> type_bool
       | "ne_str"             -> type_bool
       | "is_cunpred_exc"     -> type_bool
@@ -1260,6 +1257,9 @@ module CommonSubExprElim = struct
       | "append_bits"        -> Type_Bits(num)
       | "cvt_int_bits"       -> Type_Bits(num)
       | "cvt_bits_uint"      -> type_integer
+      | "cvt_bits_sint"      -> type_integer
+      | "eq_bits"            -> type_bool
+      | "ne_bits"            -> type_bool
       | _ -> raise (CSEError ("Can't infer type of strange primitive: " ^ (pp_expr e)))
       end
     | Expr_TApply((FIdent(name, _) | Ident(name)), [Expr_LitInt(v1) as num1; Expr_LitInt(v2) as num2], _) -> begin

--- a/libASL/transforms.ml
+++ b/libASL/transforms.ml
@@ -277,7 +277,7 @@ module IntToBits = struct
 
   (** Returns the bit-width of the given expression.
       Requires expression to evaluate to a bit-vector type. *)
-  let rec bits_size_of_expr (vars: ty Bindings.t) (e: expr): int =
+  let rec bits_size_of_expr (vars: ident -> int option) (e: expr): int =
     match e with
     | Expr_TApply (fn, tes, es) ->
       (match (fn, tes, es) with
@@ -307,12 +307,9 @@ module IntToBits = struct
       let wds = List.map (function | Slice_LoWd (_,Expr_LitInt n) -> int_of_string n | _ -> assert false) slice_list in
       List.fold_left (+) 0 wds
     | Expr_Var nm ->
-      (match Bindings.find_opt nm vars with
-      | Some (Type_Bits (Expr_LitInt n)) -> int_of_string n
-      | Some t ->
-        failwith @@ "bits_size_of_expr: expected bits type but got " ^
-        pp_type t ^ " for " ^ pp_expr e
-      | None -> failwith @@ "bits_size_of_expr: no type known for " ^ pp_expr e
+      (match vars nm with
+      | Some w -> w
+      | None -> failwith @@ "bits_size_of_expr: no width known for " ^ pp_expr e
       )
     | _ -> failwith @@ "bits_size_of_expr: unhandled " ^ pp_expr e
 
@@ -324,14 +321,14 @@ module IntToBits = struct
     | _ -> failwith @@ "bits_size_of_val: unhandled " ^ pp_value v
 
   (** Returns the bit-width of the given symbolic. *)
-  let bits_size_of_sym ?(vars = Bindings.empty)= function
+  let bits_size_of_sym vars = function
     | Val v -> bits_size_of_val v
     | Exp e -> bits_size_of_expr vars e
 
   (** Extends the given symbolic to the given size,
       treating it as a signed two's complement expression. *)
-  let bits_sign_extend (size: int) (e: sym) =
-    let old = bits_size_of_sym e in
+  let bits_sign_extend vars (size: int) (e: sym) =
+    let old = bits_size_of_sym vars e in
     assert (old <= size);
     if old = size
       then e
@@ -354,9 +351,9 @@ module IntToBits = struct
       along with the bit width,
       including coercing integers to two's complement bits where
       needed. *)
-  let bits_with_size_of_expr e =
+  let bits_with_size_of_expr vars e =
     let e' = bits_coerce_of_expr e in
-    e', bits_size_of_sym e'
+    e', bits_size_of_sym vars e'
 
   let is_power_of_2 n = 
     n <> 0 && 0 = Int.logand n (n-1)
@@ -366,6 +363,55 @@ module IntToBits = struct
       are applied. *)
   class bits_coerce_widening = object (self)
     inherit Asl_visitor.nopAslVisitor
+
+    val mutable state : (bool * int) Bindings.t = Bindings.empty
+
+    method tracked (i: ident): bool =
+      Bindings.mem i state
+
+    method addConstraint (i: ident) (w: int): unit =
+      match Bindings.find_opt i state with
+      | None ->
+          (* Introduce new width *)
+          state <- Bindings.add i (false,w) state
+      | Some (false, w') ->
+          (* Take max width of existing and new *)
+          state <- Bindings.add i (false,max w w') state
+      | Some (true, w') when w > w' ->
+          (* Width has been fixed by a use but new value won't fit *)
+          (* Assumption to avoid widening uses of i in a subsquent pass *)
+          failwith @@ "bits_coerce_widening: Reassignment of larger width post use: " ^ (pprint_ident i)
+      | _ -> ()
+
+    method useVar (i: ident): int option =
+      match Bindings.find_opt i state with
+      | None -> None
+      | Some (_,w) ->
+          state <- Bindings.add i (true,w) state;
+          Some w
+
+    method getWidth = bits_with_size_of_expr self#useVar
+
+    method signExtend = bits_sign_extend self#useVar
+
+    method dump = Bindings.iter (fun k (f,v) -> Printf.printf "%s : %d\n" (pprint_ident k) v) state
+
+    method! vstmt s =
+      ChangeDoChildrenPost (s, fun s ->
+        match s with
+        | Stmt_VarDeclsNoInit(ty, [v], loc) when ty = type_integer ->
+            self#addConstraint v 0;
+            s
+        | Stmt_ConstDecl(ty, v, e, loc)
+        | Stmt_VarDecl(ty, v, e, loc) when ty = type_integer ->
+            let (_,w) = self#getWidth e in
+            self#addConstraint v w;
+            s
+        | Stmt_Assign(LExpr_Var(v), e, loc) when self#tracked v ->
+            let (_,w) = self#getWidth e in
+            self#addConstraint v w;
+            s
+        | _ -> s)
 
     val no_int_conversion = List.map (fun f -> FIdent (f, 0)) 
       []
@@ -390,10 +436,10 @@ module IntToBits = struct
         ChangeDoChildrenPost (Expr_Tuple args, fun e' -> 
           match e' with 
           | Expr_Tuple [x; y] -> 
-            let (x,xsize) = bits_with_size_of_expr x in
-            let (y,ysize) = bits_with_size_of_expr y in
+            let (x,xsize) = self#getWidth x in
+            let (y,ysize) = self#getWidth y in
             let size = max xsize ysize + 1 in
-            let ex = bits_sign_extend size in
+            let ex = self#signExtend size in
             sym_expr @@ sym_prim (FIdent ("sdiv_bits", 0)) [sym_of_int size] [ex x; ex y]
           | _ -> failwith "expected tuple in round divide real case."
         )
@@ -413,60 +459,60 @@ module IntToBits = struct
             sym_expr @@ sym_slice Unknown (bits_coerce_of_expr e) 0 (int_of_expr t)
           | Expr_TApply (FIdent ("cvt_int_bits", 0), [t], [e;_]) -> 
             let e' = bits_coerce_of_expr e in
-            sym_expr @@ bits_sign_extend (int_of_expr t) e'
+            sym_expr @@ self#signExtend (int_of_expr t) e'
           | Expr_TApply (FIdent ("add_int", 0), [], [x;y]) ->
-            let (x,xsize) = bits_with_size_of_expr x in
-            let (y,ysize) = bits_with_size_of_expr y in
+            let (x,xsize) = self#getWidth x in
+            let (y,ysize) = self#getWidth y in
             let size = max xsize ysize + 1 in
-            let ex = bits_sign_extend size in
+            let ex = self#signExtend size in
             (* Printf.printf "x %s\ny %s\n" (pp_expr x) (pp_expr y) ; *)
             sym_expr @@ sym_prim (FIdent ("add_bits", 0)) [sym_of_int size] [ex x;ex y]
 
           | Expr_TApply (FIdent ("sub_int", 0), [], [x;y]) ->
-            let (x,xsize) = bits_with_size_of_expr x in
-            let (y,ysize) = bits_with_size_of_expr y in
+            let (x,xsize) = self#getWidth x in
+            let (y,ysize) = self#getWidth y in
             let size = max xsize ysize + 1 in
-            let ex = bits_sign_extend size in
+            let ex = self#signExtend size in
             (* Printf.printf "x %s\ny %s\n" (pp_expr x) (pp_expr y) ; *)
             sym_expr @@ sym_prim (FIdent ("sub_bits", 0)) [sym_of_int size] [ex x; ex y]
 
           | Expr_TApply (FIdent ("eq_int", 0), [], [x;y]) ->
-            let (x,xsize) = bits_with_size_of_expr x in
-            let (y,ysize) = bits_with_size_of_expr y in
+            let (x,xsize) = self#getWidth x in
+            let (y,ysize) = self#getWidth y in
             let size = max xsize ysize in
-            let ex = bits_sign_extend size in
+            let ex = self#signExtend size in
             sym_expr @@ sym_prim (FIdent ("eq_bits", 0)) [sym_of_int size] [ex x; ex y]
 
           | Expr_TApply (FIdent ("ne_int", 0), [], [x;y]) ->
-            let (x,xsize) = bits_with_size_of_expr x in
-            let (y,ysize) = bits_with_size_of_expr y in
+            let (x,xsize) = self#getWidth x in
+            let (y,ysize) = self#getWidth y in
             let size = max xsize ysize in
-            let ex = bits_sign_extend size in
+            let ex = self#signExtend size in
             sym_expr @@ sym_prim (FIdent ("ne_bits", 0)) [sym_of_int size] [ex x; ex y]
 
           | Expr_TApply (FIdent ("mul_int", 0), [], [x;y]) ->
-            let (x,xsize) = bits_with_size_of_expr x in
-            let (y,ysize) = bits_with_size_of_expr y in
+            let (x,xsize) = self#getWidth x in
+            let (y,ysize) = self#getWidth y in
             let size = xsize + ysize in
-            let ex = bits_sign_extend size in
+            let ex = self#signExtend size in
             sym_expr @@ sym_prim (FIdent ("mul_bits", 0)) [sym_of_int size] [ex x; ex y]
 
             (* x >= y  iff  y <= x  iff  x - y >= 0*)
           | Expr_TApply (FIdent ("ge_int", 0), [], [x;y])
           | Expr_TApply (FIdent ("le_int", 0), [], [y;x]) ->
-            let (x,xsize) = bits_with_size_of_expr x in
-            let (y,ysize) = bits_with_size_of_expr y in
+            let (x,xsize) = self#getWidth x in
+            let (y,ysize) = self#getWidth y in
             let size = max xsize ysize in
-            let ex x = sym_expr (bits_sign_extend size x) in
+            let ex x = sym_expr (self#signExtend size x) in
             expr_prim' "sle_bits" [expr_of_int size] [ex y;ex x]
 
             (* x < y  iff  y > x  iff x - y < 0 *)
           | Expr_TApply (FIdent ("lt_int", 0), [], [x;y])
           | Expr_TApply (FIdent ("gt_int", 0), [], [y;x]) ->
-            let (x,xsize) = bits_with_size_of_expr x in
-            let (y,ysize) = bits_with_size_of_expr y in
+            let (x,xsize) = self#getWidth x in
+            let (y,ysize) = self#getWidth y in
             let size = max xsize ysize in
-            let ex x = sym_expr (bits_sign_extend size x) in
+            let ex x = sym_expr (self#signExtend size x) in
             expr_prim' "slt_bits" [expr_of_int size] [ex x;ex y]
           (* NOTE: sle_bits and slt_bits are signed less or equal,
              and signed less than.
@@ -474,17 +520,17 @@ module IntToBits = struct
              we take advantage of them. *)
 
           | Expr_TApply (FIdent ("neg_int", 0), [], [x]) ->
-            let (x,xsize) = bits_with_size_of_expr x in
+            let (x,xsize) = self#getWidth x in
             let size = xsize + 1 in
-            let ex x = sym_expr (bits_sign_extend size x) in
+            let ex x = sym_expr (self#signExtend size x) in
             expr_prim' "neg_bits" [expr_of_int size] [ex x]
 
           | Expr_TApply (FIdent ("shl_int", 0), [], [x; y]) -> 
-            let (x,xsize) = bits_with_size_of_expr x in
-            let (y,ysize) = bits_with_size_of_expr y in
+            let (x,xsize) = self#getWidth x in
+            let (y,ysize) = self#getWidth y in
             (* in worst case, could shift by 2^(ysize-1)-1 bits, assuming y >= 0. *)
             let size = xsize + Int.shift_left 2 (ysize - 1) - 1 in
-            let ex x = sym_expr (bits_sign_extend size x) in
+            let ex x = sym_expr (self#signExtend size x) in
             (match y with 
             | Val (VBits bv) -> 
               (* if shift is statically known, simply append zeros. *)
@@ -494,27 +540,27 @@ module IntToBits = struct
             )
 
           | Expr_TApply (FIdent ("shr_int", 0), [], [x; y]) -> 
-            let (x,xsize) = bits_with_size_of_expr x in
-            let (y,ysize) = bits_with_size_of_expr y in
+            let (x,xsize) = self#getWidth x in
+            let (y,ysize) = self#getWidth y in
             let size = xsize in
-            let ex x = sym_expr (bits_sign_extend size x) in
+            let ex x = sym_expr (self#signExtend size x) in
             expr_prim' "asr_bits" [expr_of_int size; expr_of_int ysize] [ex x;sym_expr y]
 
             (* these functions take bits as first argument and integer as second. just coerce second to bits. *)
           | Expr_TApply (FIdent ("LSL", 0), [size], [x; n]) -> 
-            let (n,nsize) = bits_with_size_of_expr n in
+            let (n,nsize) = self#getWidth n in
             expr_prim' "lsl_bits" [size; expr_of_int nsize] [x;sym_expr n]
           | Expr_TApply (FIdent ("LSR", 0), [size], [x; n]) -> 
-            let (n,nsize) = bits_with_size_of_expr n in
+            let (n,nsize) = self#getWidth n in
             expr_prim' "lsr_bits" [size; expr_of_int nsize] [x;sym_expr n]
           | Expr_TApply (FIdent ("ASR", 0), [size], [x; n]) -> 
-            let (n,nsize) = bits_with_size_of_expr n in
+            let (n,nsize) = self#getWidth n in
             expr_prim' "asr_bits" [size; expr_of_int nsize] [x;sym_expr n]
 
             (* when the divisor is a power of 2, mod can be implemented by truncating. *)
           | Expr_TApply (FIdent ("frem_int", 0), [], [n;Expr_LitInt d]) when is_power_of_2 (int_of_string d) ->
             let digits = Z.log2 (Z.of_string d) in
-            let n,_ = bits_with_size_of_expr n in
+            let n,_ = self#getWidth n in
             sym_expr @@ sym_zero_extend 1 digits (sym_slice Unknown n 0 digits)
 
             (* very carefully coerce a signed integer to a "real" by just using its signed representation *)
@@ -538,6 +584,11 @@ module IntToBits = struct
 
     val mutable var_types : ty Bindings.t = Bindings.empty;
 
+    method varWidth (i: ident): int option =
+      match Bindings.find_opt i var_types with
+      | Some (Type_Bits (Expr_LitInt n)) -> Some (int_of_string n)
+      | _ -> None
+
     method! vstmt s =
       match s with
       | Stmt_ConstDecl(ty, nm, _, _) ->
@@ -555,7 +606,7 @@ module IntToBits = struct
         let narrow e =
           (* Printf.printf "slicing %s\n" (pp_expr e); *)
           let e' = sym_of_expr e in
-          let size = bits_size_of_sym ~vars:var_types e' in
+          let size = bits_size_of_sym self#varWidth e' in
           let ext = wd' - size in
           (* if expression is shorter than slice, extend it as needed. *)
           let e' = if ext > 0 then (sym_sign_extend ext size e') else e' in
@@ -578,10 +629,45 @@ module IntToBits = struct
 
   end
 
+  class redecl_integers (widths: ident -> int option) = object (self)
+    inherit Asl_visitor.nopAslVisitor
+
+    method cast (e: expr) (w: int) =
+      let e = bits_coerce_of_expr e in
+      sym_expr (bits_sign_extend widths w e)
+
+    method tracked (i: ident): bool =
+      match widths i with
+      | Some v -> true
+      | _ -> false
+
+    method! vstmt s =
+      match s with
+      | Stmt_VarDeclsNoInit(ty, [v], loc) when ty = type_integer ->
+          (match widths v with
+          | Some w -> ChangeTo (Stmt_VarDeclsNoInit (type_bits (string_of_int w), [v], loc))
+          | None -> SkipChildren)
+      | Stmt_ConstDecl(ty, v, e, loc)  when ty = type_integer ->
+          (match widths v with
+          | Some w -> ChangeTo (Stmt_ConstDecl (type_bits (string_of_int w), v, self#cast e w, loc))
+          | None -> SkipChildren)
+      | Stmt_VarDecl(ty, v, e, loc) when ty = type_integer ->
+          (match widths v with
+          | Some w -> ChangeTo (Stmt_VarDecl (type_bits (string_of_int w), v, self#cast e w, loc))
+          | None -> SkipChildren)
+      | Stmt_Assign(LExpr_Var(v), e, loc) ->
+          (match widths v with
+          | Some w -> ChangeTo (Stmt_Assign (LExpr_Var(v), self#cast e w, loc))
+          | None -> SkipChildren)
+      | _ -> DoChildren
+
+  end
+
   let ints_to_bits xs =
-    xs
-    |> Asl_visitor.visit_stmts (new bits_coerce_widening)
-    |> Asl_visitor.visit_stmts (new bits_coerce_narrow)
+    let w = new bits_coerce_widening in
+    let xs = Asl_visitor.visit_stmts w xs in
+    let xs = Asl_visitor.visit_stmts (new redecl_integers w#useVar) xs in
+    Asl_visitor.visit_stmts (new bits_coerce_narrow) xs
 
 end
 

--- a/libASL/transforms.ml
+++ b/libASL/transforms.ml
@@ -225,37 +225,45 @@ end
 
 module StatefulIntToBits = struct
   type interval = (Z.t * Z.t)
-  type abs = (int * interval)
+  type abs = (int * bool * interval)
   type state = (bool * abs Bindings.t)
 
   (** Compute the bitvector width needed to represent an interval *)
-  let width_of_interval ((u,l): interval): int =
-    let u' = if Z.gt u Z.zero then 1 + (Z.log2up (Z.succ u)) else 1 in
-    let l' = if Z.lt l Z.zero then 1 + (Z.log2up (Z.abs u)) else 1 in
-    (max u' l')
+  let width_of_interval  ?(force_signed=false) ((u,l): interval): int * bool =
+    if not force_signed && Z.geq l Z.zero then 
+      let i = max (Z.log2up (Z.succ u)) 1 in
+      (i,false)
+    else
+      let u' = if Z.gt u Z.zero then 1 + (Z.log2up (Z.succ u)) else 1 in
+      let l' = if Z.lt l Z.zero then 1 + (Z.log2up (Z.abs u)) else 1 in
+      (max u' l',true)
 
   (** Build an abstract point to represent a constant integer *)
   let abs_of_const (c: Z.t): abs =
     let i = (c,c) in
-    (width_of_interval i,i) 
+    let (w,s) = width_of_interval i in
+    (w,s,i)
 
   (** Build an abstract point for all values possible in a bv of width w *)
   let abs_of_width (w: int): abs =
     let t = Z.succ (Z.one) in
     let u = Z.pred (Z.pow t (w - 1)) in
     let l = Z.pow t (w - 1) in
-    (w, (u,l))
+    (w, true, (u,l))
 
   (** Build an abstract point for unsigned integer in signed representation *)
   let abs_of_uwidth (w: int): abs =
     let t = Z.succ (Z.one) in
     let u = Z.pred (Z.pow t w) in
     let l = Z.zero in
-    (w + 1, (u,l))
+    (w, false, (u,l))
 
   (* Basic merge of abstract points *)
-  let merge_abs ((lw,(l1,l2)): abs) ((rw,(r1,r2)): abs): abs =
-    (max lw rw,(Z.max r1 l1,Z.min r2 l2))
+  let merge_abs ((lw,ls,(l1,l2)): abs) ((rw,rs,(r1,r2)): abs): abs =
+    let s = ls || rs in
+    let lw = if s && not ls then lw + 1 else lw in
+    let rw = if s && not rs then rw + 1 else rw in
+    (max lw rw,s,(Z.max r1 l1,Z.min r2 l2))
 
   (** Max and min of a list of integers *)
   let maxAll (z: Z.t list): Z.t =
@@ -276,26 +284,53 @@ module StatefulIntToBits = struct
      minAll [uop l1;uop l2])
 
   (** Preserve abstract points over bops and uops *)
-  let abs_of_bop ((lw,li): abs) ((rw,ri): abs) (bop: Z.t -> Z.t -> Z.t): abs =
+  let abs_of_bop ((lw,ls,li): abs) ((rw,rs,ri): abs) (bop: Z.t -> Z.t -> Z.t): abs =
     let i = bopInterval li ri bop in
-    let w = max lw rw in
-    (max w (width_of_interval i),i)
-  let abs_of_uop ((lw,li): abs) (uop: Z.t -> Z.t): abs =
+    let (iw,s) = width_of_interval ~force_signed:(ls||rs) i in
+    let lw = if s && not ls then lw + 1 else lw in
+    let rw = if s && not rs then rw + 1 else rw in
+    let w = max (max lw rw) iw in
+    (w,s,i)
+  let abs_of_uop ((lw,ls,li): abs) (uop: Z.t -> Z.t): abs =
     let i = uopInterval li uop in
-    (max lw (width_of_interval i),i)
+    let (iw,s) = width_of_interval ~force_signed:ls i in
+    let lw = if s && not ls then lw + 1 else lw in
+    let w = max lw iw in
+    (w,s,i)
+
+  (* alternative is to derive the signedness directly from the interval *)
+
+  let width (n,_,_) = n
+  let signed (_,s,_) = s
+  let interval (_,_,i) = i
 
   (** Convert abstract point width into exprs & symbols *)
-  let expr_of_abs ((n,_)) =
-    Expr_LitInt (string_of_int n)
-  let sym_of_abs ((size,_): abs): sym =
-    sym_of_int size
+  let expr_of_abs a =
+    Expr_LitInt (string_of_int (width a))
+  let sym_of_abs a: sym =
+    sym_of_int (width a)
+
+  (* Covert an expression and its abstract information to a signed representation *)
+  let force_signed (e,old) =
+    if signed old then (e,old)
+    else
+      let abs = (width old + 1, true, interval old) in
+      (sym_zero_extend 1 (width old) e, abs)
 
   (** Extend an expression coupled with its abstract information to a width *)
-  let sign_extend (size) ((e,(old,_)) : sym * abs) =
-    assert (old <= size);
-    if old = size
-      then e
-      else (sym_sign_extend (size - old) old e)
+  let extend (abs) ((e,old) : sym * abs) =
+    (* Only extending *)
+    assert (width old <= width abs);
+    (* Only going from unsigned to signed *)
+    assert ((not (signed old)) || signed abs);
+    if signed abs && not (signed old) then
+      let e = sym_zero_extend 1 (width old) e in
+      let w = width old + 1 in
+      if w = width abs then e
+      else sym_sign_extend (width abs - w) w e
+    else if width abs = width old then e 
+    else if not (signed abs) then sym_zero_extend (width abs - width old) (width old) e
+    else sym_sign_extend (width abs - width old) (width old) e
 
   let is_power_of_2 n = 
     n <> 0 && 0 = Int.logand n (n-1)
@@ -308,8 +343,8 @@ module StatefulIntToBits = struct
     | Expr_LitHex n ->
         let n = Z.of_string (Value.drop_chars n ' ') in
         let w = abs_of_const n in
-        let a = Z.extract n 0 (fst w) in
-        (sym_of_expr (Expr_LitBits (Z.format ("%0" ^ string_of_int (fst w) ^ "b") a)),w)
+        let a = Z.extract n 0 (width w) in
+        (sym_of_expr (Expr_LitBits (Z.format ("%0" ^ string_of_int (width w) ^ "b") a)),w)
 
     (* Assume variables have been declared at this point *)
     | Expr_Var i -> 
@@ -320,7 +355,7 @@ module StatefulIntToBits = struct
     | Expr_TApply (FIdent ("cvt_bits_uint", 0), [t], [e]) ->
         let n = int_of_expr t in
         let w = abs_of_uwidth n in
-        (sym_zero_extend 1 n (sym_of_expr e),w)
+        (sym_of_expr e,w)
     | Expr_TApply (FIdent ("cvt_bits_sint", 0), [t], [e]) ->
         let n = int_of_expr t in
         let w = abs_of_width n in
@@ -330,21 +365,21 @@ module StatefulIntToBits = struct
         let x = bv_of_int_expr vars x in
         let y = bv_of_int_expr vars y in
         let w = abs_of_bop (snd x) (snd y) Primops.prim_add_int in
-        let ex = sign_extend (fst w) in
+        let ex = extend w in
         let f = sym_prim (FIdent ("add_bits", 0)) [sym_of_abs w] [ex x;ex y] in
         (f,w)
     | Expr_TApply (FIdent ("sub_int", 0), [], [x;y]) ->
         let x = bv_of_int_expr vars x in
         let y = bv_of_int_expr vars y in
         let w = abs_of_bop (snd x) (snd y) Primops.prim_sub_int in
-        let ex = sign_extend (fst w) in
+        let ex = extend w in
         let f = sym_prim (FIdent ("sub_bits", 0)) [sym_of_abs w] [ex x;ex y] in
         (f,w)
     | Expr_TApply (FIdent ("mul_int", 0), [], [x;y]) ->
         let x = bv_of_int_expr vars x in
         let y = bv_of_int_expr vars y in
         let w = abs_of_bop (snd x) (snd y) Primops.prim_mul_int in
-        let ex = sign_extend (fst w) in
+        let ex = extend w in
         let f = sym_prim (FIdent ("mul_bits", 0)) [sym_of_abs w] [ex x;ex y] in
         (f,w)
 
@@ -352,40 +387,43 @@ module StatefulIntToBits = struct
     | Expr_TApply (FIdent ("frem_int", 0), [], [n;Expr_LitInt d]) when is_power_of_2 (int_of_string d) ->
         let digits = Z.log2 (Z.of_string d) in
         let n = bv_of_int_expr vars n in
-        if fst (snd n) <= digits then n
+        if width (snd n) <= digits then n
         else 
-          let f = sym_zero_extend 1 digits @@ sym_slice Unknown (fst n) 0 digits in
-          let w = abs_of_width (digits + 1) in
+          let f = sym_slice Unknown (fst n) 0 digits in
+          let w = abs_of_uwidth digits in
           (f,w)
 
-    (* TODO: Plus 1? *)
     | Expr_TApply (FIdent ("neg_int", 0), [], [x]) ->
         let x = bv_of_int_expr vars x in
         let w = abs_of_uop (snd x) Primops.prim_neg_int in
-        let ex = sign_extend (fst w) in
+        let ex = extend w in
         let f = sym_prim (FIdent ("neg_bits", 0)) [sym_of_abs w] [ex x] in
         (f,w)
 
     (* TODO: Somewhat haphazard translation from old approach *)
     | Expr_TApply (FIdent ("shl_int", 0), [], [x; y]) -> 
         let x = bv_of_int_expr vars x in
-        let y = bv_of_int_expr vars y in
-        (* in worst case, could shift by 2^(ysize-1)-1 bits, assuming y >= 0. *)
-        let size = fst (snd x) + Int.shift_left 2 (fst (snd y) - 1) - 1 in
-        let ex = sign_extend size in
+        let y = force_signed (bv_of_int_expr vars y) in
         (match fst y with
         | Val (VBits bv) ->
             let yshift = Z.to_int (Primops.prim_cvt_bits_sint bv) in 
-            let w = abs_of_width (yshift + (fst (snd x))) in
-            (sym_append_bits Unknown (fst (snd x)) yshift (fst x) (sym_zeros yshift),w)
+            let size = width (snd x) + yshift in
+            let abs = if signed (snd x) then abs_of_width size else abs_of_uwidth size in
+            (sym_append_bits Unknown (width (snd x)) yshift (fst x) (sym_zeros yshift),abs)
         | _ -> 
-            (sym_prim (FIdent ("lsl_bits", 0)) [sym_of_int size; sym_of_abs (snd y)] [ex x;fst y],abs_of_width size)
+            let (u,_) = interval (snd y) in
+            (* in worst case, could shift by 2^(ysize-1)-1 bits, assuming y >= 0. *)
+            let size = width (snd x) + (Int.shift_left 2 (Z.to_int u)) - 1 in
+            let abs = if signed (snd x) then abs_of_width size else abs_of_uwidth size in
+            let ex = extend abs in
+            let f = sym_prim (FIdent ("lsl_bits", 0)) [sym_of_int size; sym_of_abs (snd y)] [ex x;fst y] in
+            (f,abs)
         )
 
     (* TODO: Over-approximate range on result, could be a little closer *)
     | Expr_TApply (FIdent ("shr_int", 0), [], [x; y]) -> 
         let x = bv_of_int_expr vars x in
-        let y = bv_of_int_expr vars y in
+        let y = force_signed (bv_of_int_expr vars y) in
         (sym_prim (FIdent ("asr_bits", 0)) [sym_of_abs (snd x); sym_of_abs (snd y)] [fst x;fst y],snd x)
 
     (* truncated division with detour via floats *)
@@ -393,11 +431,12 @@ module StatefulIntToBits = struct
         [Expr_TApply (FIdent ("divide_real",0), [], 
           [Expr_TApply (FIdent ("cvt_int_real", 0), [], [x]); 
             Expr_TApply (FIdent ("cvt_int_real", 0), [], [y])])]) -> 
-          let x = bv_of_int_expr vars x in
-          let y = bv_of_int_expr vars y in
+          (* Force a signed representation for use with sdiv *)
+          let x = force_signed (bv_of_int_expr vars x) in
+          let y = force_signed (bv_of_int_expr vars y) in
           (* Assume result fits within merge of both widths *)
           let w = merge_abs (snd x) (snd y) in
-          let ex = sign_extend (fst w) in
+          let ex = extend w in
           let f = sym_prim (FIdent ("sdiv_bits", 0)) [sym_of_abs w] [ex x; ex y] in
           (f,w)
 
@@ -418,58 +457,60 @@ module StatefulIntToBits = struct
           let l = int_of_expr l in
           let w = int_of_expr w in
           (match bv_of_int_expr_opt vars x with
-          | Some x -> 
-              let old = fst (snd x) in
-              let x = if old <= l + w then sign_extend (l+w) x else fst x in
+          | Some (e,a) -> 
+              let x = if width a <= l + w then extend (l+w,signed a,interval a) (e,a) else e in
               sym_expr @@ sym_slice Unknown x l w
           | None -> e)
 
       (* Other translation from int to bit *)
       | Expr_TApply (FIdent ("cvt_int_bits", 0), [t], [e;_]) -> 
           let e' = bv_of_int_expr vars e in
-          sym_expr @@ sign_extend (int_of_expr t) e'
+          let abs = (int_of_expr t,true,(Z.zero,Z.zero)) in
+          sym_expr @@ extend abs e'
 
       | Expr_TApply (FIdent ("eq_int", 0), [], [x;y]) ->
           let x = bv_of_int_expr vars x in
           let y = bv_of_int_expr vars y in
           let w = merge_abs (snd x) (snd y) in
-          let ex = sign_extend (fst w) in
+          let ex = extend w in
           sym_expr @@ sym_prim (FIdent ("eq_bits", 0)) [sym_of_abs w] [ex x; ex y]
 
       | Expr_TApply (FIdent ("ne_int", 0), [], [x;y]) ->
           let x = bv_of_int_expr vars x in
           let y = bv_of_int_expr vars y in
           let w = merge_abs (snd x) (snd y) in
-          let ex = sign_extend (fst w) in
+          let ex = extend w in
           sym_expr @@ sym_prim (FIdent ("ne_bits", 0)) [sym_of_abs w] [ex x; ex y]
 
       (* x >= y  iff  y <= x  iff  x - y >= 0*)
       | Expr_TApply (FIdent ("ge_int", 0), [], [x;y])
       | Expr_TApply (FIdent ("le_int", 0), [], [y;x]) ->
-          let x = bv_of_int_expr vars x in
-          let y = bv_of_int_expr vars y in
+          let x = force_signed (bv_of_int_expr vars x) in
+          let y = force_signed (bv_of_int_expr vars y) in
           let w = merge_abs (snd x) (snd y) in
-          let ex x = sym_expr (sign_extend (fst w) x) in
+          let ex x = sym_expr (extend w x) in
           expr_prim' "sle_bits" [expr_of_abs w] [ex y;ex x]
 
       (* x < y  iff  y > x  iff x - y < 0 *)
       | Expr_TApply (FIdent ("lt_int", 0), [], [x;y])
       | Expr_TApply (FIdent ("gt_int", 0), [], [y;x]) ->
-          let x = bv_of_int_expr vars x in
-          let y = bv_of_int_expr vars y in
+          let x = force_signed (bv_of_int_expr vars x) in
+          let y = force_signed (bv_of_int_expr vars y) in
           let w = merge_abs (snd x) (snd y) in
-          let ex x = sym_expr (sign_extend (fst w) x) in
+          let ex x = sym_expr (extend w x) in
           expr_prim' "slt_bits" [expr_of_abs w] [ex x;ex y]
 
       (* these functions take bits as first argument and integer as second. just coerce second to bits. *)
+      (* TODO: primitive implementations of these expressions expect the shift amount to be signed,
+               but a negative shift is invalid anyway. Can't it just be unsigned? *)
       | Expr_TApply (FIdent ("LSL", 0), [size], [x; n]) -> 
-          let (n,w) = bv_of_int_expr vars n in
+          let (n,w) = force_signed (bv_of_int_expr vars n) in
           expr_prim' "lsl_bits" [size; expr_of_abs w] [x;sym_expr n]
       | Expr_TApply (FIdent ("LSR", 0), [size], [x; n]) -> 
-          let (n,w) = bv_of_int_expr vars n in
+          let (n,w) = force_signed (bv_of_int_expr vars n) in
           expr_prim' "lsr_bits" [size; expr_of_abs w] [x;sym_expr n]
       | Expr_TApply (FIdent ("ASR", 0), [size], [x; n]) -> 
-          let (n,w) = bv_of_int_expr vars n in
+          let (n,w) = force_signed (bv_of_int_expr vars n) in
           expr_prim' "asr_bits" [size; expr_of_abs w] [x;sym_expr n]
 
       | e -> e
@@ -480,27 +521,23 @@ module StatefulIntToBits = struct
   (** Get a variable's abstract rep with a default initial value *)
   let get_default (v: ident) ((_,vars): state): abs =
     match Bindings.find_opt v vars with
-    | Some w -> w
+    | Some (a,b,_) -> (a,b,(Z.zero,Z.zero))
     | _ -> abs_of_const Z.zero
 
   (** Declare a new variable with an initial abstract rep *)
-  let decl (v: ident) (i: abs) ((f,vars): state): state =
-    match Bindings.find_opt v vars with
-    | Some (w,_) -> 
-        if w = fst i then (f,vars)
-        else if w = fst i then (f,Bindings.add v i vars)
-        else (true,Bindings.add v (max w (fst i), snd i) vars)
-    | None -> (true,Bindings.add v i vars)
-
-  (** Assign an existing variable *)
   let assign (v: ident) (i: abs) ((f,vars): state): state =
     match Bindings.find_opt v vars with
     | Some j -> 
-        let m = merge_abs i j in
-        if m = j then (f,vars)
-        else if fst m = fst j then (f,Bindings.add v m vars)
-        else (true,Bindings.add v m vars)
-    | None -> failwith @@ "int2bit: assigning to variable that does not exist " ^ (pprint_ident v)
+        (* Entry doesn't change, nothing to do *)
+        if i = j then (f,vars)
+        (* Same width and sign, but redecl resets range, not a real change *)
+        else if width i = width j && signed i = signed j then (f,Bindings.add v i vars)
+        else 
+          (* Merge width and sign, but keep new range for range analysis *)
+          let (w,s,_) = merge_abs i j in
+          let m = (w,s,interval i) in
+          (true,Bindings.add v m vars)
+    | None -> (true,Bindings.add v i vars)
 
   (** Simple test of existence in state *)
   let tracked (v: ident) ((_,vars): state): bool =
@@ -528,30 +565,30 @@ module StatefulIntToBits = struct
       (* Match integer writes *)
       | Stmt_VarDeclsNoInit(t, [v], loc) when t = type_integer ->
           let lhs = get_default v st in
-          let e = Stmt_VarDeclsNoInit (type_bits (string_of_int (fst lhs)), [v], loc) in
-          let st = decl v lhs st in
+          let e = Stmt_VarDeclsNoInit (type_bits (string_of_int (width lhs)), [v], loc) in
+          let st = assign v lhs st in
           (st,e)
       | Stmt_ConstDecl(t, v, e, loc) when t = type_integer ->
           let lhs = get_default v st in
           let rhs = bv_of_int_expr st e in
           let w = merge_abs lhs (snd rhs) in
-          let s = sym_expr (sign_extend (fst w) rhs) in
-          let s = Stmt_ConstDecl (type_bits (string_of_int (fst w)), v, s, loc) in
-          let st = decl v w st in
+          let s = sym_expr (extend w rhs) in
+          let s = Stmt_ConstDecl (type_bits (string_of_int (width w)), v, s, loc) in
+          let st = assign v w st in
           (st,s)
       | Stmt_VarDecl(t, v, e, loc) when t = type_integer ->
           let lhs = get_default v st in
           let rhs = bv_of_int_expr st e in
           let w = merge_abs lhs (snd rhs) in
-          let s = sym_expr (sign_extend (fst w) rhs) in
-          let s = Stmt_VarDecl (type_bits (string_of_int (fst w)), v, s, loc) in
-          let st = decl v w st in
+          let s = sym_expr (extend w rhs) in
+          let s = Stmt_VarDecl (type_bits (string_of_int (width w)), v, s, loc) in
+          let st = assign v w st in
           (st,s)
       | Stmt_Assign(LExpr_Var(v), e, loc) when tracked v st ->
           let lhs = get_default v st in
           let rhs = bv_of_int_expr st e in
           let w = merge_abs lhs (snd rhs) in
-          let s = sym_expr (sign_extend (fst w) rhs) in
+          let s = sym_expr (extend w rhs) in
           let s = Stmt_Assign (LExpr_Var(v), s, loc) in
           let st = assign v w st in
           (st,s)

--- a/tests/coverage/aarch64_integer___
+++ b/tests/coverage/aarch64_integer___
@@ -51,9 +51,9 @@ ENCODING: aarch64_integer_arithmetic_add_sub_carry
 0x3a1f0020: [sf=0 ; op=0 ; S=1 ; Rm=31 ; Rn=1 ; Rd=0] --> OK
 0x3a1f0021: [sf=0 ; op=0 ; S=1 ; Rm=31 ; Rn=1 ; Rd=1] --> OK
 0x3a1f003f: [sf=0 ; op=0 ; S=1 ; Rm=31 ; Rn=1 ; Rd=31] --> OK
-0x3a1f03e0: [sf=0 ; op=0 ; S=1 ; Rm=31 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: File "libASL/primops.ml", line 194, characters 4-10: Assertion failed
-0x3a1f03e1: [sf=0 ; op=0 ; S=1 ; Rm=31 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: File "libASL/primops.ml", line 194, characters 4-10: Assertion failed
-0x3a1f03ff: [sf=0 ; op=0 ; S=1 ; Rm=31 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: File "libASL/primops.ml", line 194, characters 4-10: Assertion failed
+0x3a1f03e0: [sf=0 ; op=0 ; S=1 ; Rm=31 ; Rn=31 ; Rd=0] --> OK
+0x3a1f03e1: [sf=0 ; op=0 ; S=1 ; Rm=31 ; Rn=31 ; Rd=1] --> OK
+0x3a1f03ff: [sf=0 ; op=0 ; S=1 ; Rm=31 ; Rn=31 ; Rd=31] --> OK
 0x5a000000: [sf=0 ; op=1 ; S=0 ; Rm=0 ; Rn=0 ; Rd=0] --> OK
 0x5a000001: [sf=0 ; op=1 ; S=0 ; Rm=0 ; Rn=0 ; Rd=1] --> OK
 0x5a00001f: [sf=0 ; op=1 ; S=0 ; Rm=0 ; Rn=0 ; Rd=31] --> OK
@@ -105,9 +105,9 @@ ENCODING: aarch64_integer_arithmetic_add_sub_carry
 0x7a1f0020: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=1 ; Rd=0] --> OK
 0x7a1f0021: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=1 ; Rd=1] --> OK
 0x7a1f003f: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=1 ; Rd=31] --> OK
-0x7a1f03e0: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=0] --> OK
-0x7a1f03e1: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=1] --> OK
-0x7a1f03ff: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=31] --> OK
+0x7a1f03e0: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Invalid_argument("Z.log2up")
+0x7a1f03e1: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Invalid_argument("Z.log2up")
+0x7a1f03ff: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Invalid_argument("Z.log2up")
 0x9a000000: [sf=1 ; op=0 ; S=0 ; Rm=0 ; Rn=0 ; Rd=0] --> OK
 0x9a000001: [sf=1 ; op=0 ; S=0 ; Rm=0 ; Rn=0 ; Rd=1] --> OK
 0x9a00001f: [sf=1 ; op=0 ; S=0 ; Rm=0 ; Rn=0 ; Rd=31] --> OK
@@ -159,9 +159,9 @@ ENCODING: aarch64_integer_arithmetic_add_sub_carry
 0xba1f0020: [sf=1 ; op=0 ; S=1 ; Rm=31 ; Rn=1 ; Rd=0] --> OK
 0xba1f0021: [sf=1 ; op=0 ; S=1 ; Rm=31 ; Rn=1 ; Rd=1] --> OK
 0xba1f003f: [sf=1 ; op=0 ; S=1 ; Rm=31 ; Rn=1 ; Rd=31] --> OK
-0xba1f03e0: [sf=1 ; op=0 ; S=1 ; Rm=31 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: File "libASL/primops.ml", line 194, characters 4-10: Assertion failed
-0xba1f03e1: [sf=1 ; op=0 ; S=1 ; Rm=31 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: File "libASL/primops.ml", line 194, characters 4-10: Assertion failed
-0xba1f03ff: [sf=1 ; op=0 ; S=1 ; Rm=31 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: File "libASL/primops.ml", line 194, characters 4-10: Assertion failed
+0xba1f03e0: [sf=1 ; op=0 ; S=1 ; Rm=31 ; Rn=31 ; Rd=0] --> OK
+0xba1f03e1: [sf=1 ; op=0 ; S=1 ; Rm=31 ; Rn=31 ; Rd=1] --> OK
+0xba1f03ff: [sf=1 ; op=0 ; S=1 ; Rm=31 ; Rn=31 ; Rd=31] --> OK
 0xda000000: [sf=1 ; op=1 ; S=0 ; Rm=0 ; Rn=0 ; Rd=0] --> OK
 0xda000001: [sf=1 ; op=1 ; S=0 ; Rm=0 ; Rn=0 ; Rd=1] --> OK
 0xda00001f: [sf=1 ; op=1 ; S=0 ; Rm=0 ; Rn=0 ; Rd=31] --> OK
@@ -213,9 +213,9 @@ ENCODING: aarch64_integer_arithmetic_add_sub_carry
 0xfa1f0020: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=1 ; Rd=0] --> OK
 0xfa1f0021: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=1 ; Rd=1] --> OK
 0xfa1f003f: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=1 ; Rd=31] --> OK
-0xfa1f03e0: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=0] --> OK
-0xfa1f03e1: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=1] --> OK
-0xfa1f03ff: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=31] --> OK
+0xfa1f03e0: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Invalid_argument("Z.log2up")
+0xfa1f03e1: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Invalid_argument("Z.log2up")
+0xfa1f03ff: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Invalid_argument("Z.log2up")
 
 ENCODING: aarch64_integer_arithmetic_add_sub_extendedreg
 0x0b200000: [sf=0 ; op=0 ; S=0 ; Rm=0 ; option=0 ; imm3=0 ; Rn=0 ; Rd=0] --> OK
@@ -8488,38 +8488,38 @@ ENCODING: aarch64_integer_arithmetic_address_pc_rel
 0xf0ffffff: [op=1 ; immlo=3 ; immhi=524287 ; Rd=31] --> OK
 
 ENCODING: aarch64_integer_arithmetic_cnt
-0x5ac01000: [sf=0 ; op=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__6")
-0x5ac01001: [sf=0 ; op=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__6")
+0x5ac01000: [sf=0 ; op=0 ; Rn=0 ; Rd=0] --> OK
+0x5ac01001: [sf=0 ; op=0 ; Rn=0 ; Rd=1] --> OK
 0x5ac0101f: [sf=0 ; op=0 ; Rn=0 ; Rd=31] --> OK
-0x5ac01020: [sf=0 ; op=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__6")
-0x5ac01021: [sf=0 ; op=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__6")
+0x5ac01020: [sf=0 ; op=0 ; Rn=1 ; Rd=0] --> OK
+0x5ac01021: [sf=0 ; op=0 ; Rn=1 ; Rd=1] --> OK
 0x5ac0103f: [sf=0 ; op=0 ; Rn=1 ; Rd=31] --> OK
 0x5ac013e0: [sf=0 ; op=0 ; Rn=31 ; Rd=0] --> OK
 0x5ac013e1: [sf=0 ; op=0 ; Rn=31 ; Rd=1] --> OK
 0x5ac013ff: [sf=0 ; op=0 ; Rn=31 ; Rd=31] --> OK
-0x5ac01400: [sf=0 ; op=1 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp8__7")
-0x5ac01401: [sf=0 ; op=1 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp8__7")
+0x5ac01400: [sf=0 ; op=1 ; Rn=0 ; Rd=0] --> OK
+0x5ac01401: [sf=0 ; op=1 ; Rn=0 ; Rd=1] --> OK
 0x5ac0141f: [sf=0 ; op=1 ; Rn=0 ; Rd=31] --> OK
-0x5ac01420: [sf=0 ; op=1 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp8__7")
-0x5ac01421: [sf=0 ; op=1 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp8__7")
+0x5ac01420: [sf=0 ; op=1 ; Rn=1 ; Rd=0] --> OK
+0x5ac01421: [sf=0 ; op=1 ; Rn=1 ; Rd=1] --> OK
 0x5ac0143f: [sf=0 ; op=1 ; Rn=1 ; Rd=31] --> OK
 0x5ac017e0: [sf=0 ; op=1 ; Rn=31 ; Rd=0] --> OK
 0x5ac017e1: [sf=0 ; op=1 ; Rn=31 ; Rd=1] --> OK
 0x5ac017ff: [sf=0 ; op=1 ; Rn=31 ; Rd=31] --> OK
-0xdac01000: [sf=1 ; op=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__6")
-0xdac01001: [sf=1 ; op=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__6")
+0xdac01000: [sf=1 ; op=0 ; Rn=0 ; Rd=0] --> OK
+0xdac01001: [sf=1 ; op=0 ; Rn=0 ; Rd=1] --> OK
 0xdac0101f: [sf=1 ; op=0 ; Rn=0 ; Rd=31] --> OK
-0xdac01020: [sf=1 ; op=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__6")
-0xdac01021: [sf=1 ; op=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__6")
+0xdac01020: [sf=1 ; op=0 ; Rn=1 ; Rd=0] --> OK
+0xdac01021: [sf=1 ; op=0 ; Rn=1 ; Rd=1] --> OK
 0xdac0103f: [sf=1 ; op=0 ; Rn=1 ; Rd=31] --> OK
 0xdac013e0: [sf=1 ; op=0 ; Rn=31 ; Rd=0] --> OK
 0xdac013e1: [sf=1 ; op=0 ; Rn=31 ; Rd=1] --> OK
 0xdac013ff: [sf=1 ; op=0 ; Rn=31 ; Rd=31] --> OK
-0xdac01400: [sf=1 ; op=1 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp8__7")
-0xdac01401: [sf=1 ; op=1 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp8__7")
+0xdac01400: [sf=1 ; op=1 ; Rn=0 ; Rd=0] --> OK
+0xdac01401: [sf=1 ; op=1 ; Rn=0 ; Rd=1] --> OK
 0xdac0141f: [sf=1 ; op=1 ; Rn=0 ; Rd=31] --> OK
-0xdac01420: [sf=1 ; op=1 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp8__7")
-0xdac01421: [sf=1 ; op=1 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp8__7")
+0xdac01420: [sf=1 ; op=1 ; Rn=1 ; Rd=0] --> OK
+0xdac01421: [sf=1 ; op=1 ; Rn=1 ; Rd=1] --> OK
 0xdac0143f: [sf=1 ; op=1 ; Rn=1 ; Rd=31] --> OK
 0xdac017e0: [sf=1 ; op=1 ; Rn=31 ; Rd=0] --> OK
 0xdac017e1: [sf=1 ; op=1 ; Rn=31 ; Rd=1] --> OK
@@ -8532,8 +8532,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x1ac00820: [sf=0 ; Rm=0 ; o1=0 ; Rn=1 ; Rd=0] --> OK
 0x1ac00821: [sf=0 ; Rm=0 ; o1=0 ; Rn=1 ; Rd=1] --> OK
 0x1ac0083f: [sf=0 ; Rm=0 ; o1=0 ; Rn=1 ; Rd=31] --> OK
-0x1ac00be0: [sf=0 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Not_found
-0x1ac00be1: [sf=0 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Not_found
+0x1ac00be0: [sf=0 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
+0x1ac00be1: [sf=0 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
 0x1ac00bff: [sf=0 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=31] --> OK
 0x1ac00c00: [sf=0 ; Rm=0 ; o1=1 ; Rn=0 ; Rd=0] --> OK
 0x1ac00c01: [sf=0 ; Rm=0 ; o1=1 ; Rn=0 ; Rd=1] --> OK
@@ -8541,8 +8541,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x1ac00c20: [sf=0 ; Rm=0 ; o1=1 ; Rn=1 ; Rd=0] --> OK
 0x1ac00c21: [sf=0 ; Rm=0 ; o1=1 ; Rn=1 ; Rd=1] --> OK
 0x1ac00c3f: [sf=0 ; Rm=0 ; o1=1 ; Rn=1 ; Rd=31] --> OK
-0x1ac00fe0: [sf=0 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Not_found
-0x1ac00fe1: [sf=0 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Not_found
+0x1ac00fe0: [sf=0 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
+0x1ac00fe1: [sf=0 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
 0x1ac00fff: [sf=0 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=31] --> OK
 0x1ac10800: [sf=0 ; Rm=1 ; o1=0 ; Rn=0 ; Rd=0] --> OK
 0x1ac10801: [sf=0 ; Rm=1 ; o1=0 ; Rn=0 ; Rd=1] --> OK
@@ -8550,8 +8550,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x1ac10820: [sf=0 ; Rm=1 ; o1=0 ; Rn=1 ; Rd=0] --> OK
 0x1ac10821: [sf=0 ; Rm=1 ; o1=0 ; Rn=1 ; Rd=1] --> OK
 0x1ac1083f: [sf=0 ; Rm=1 ; o1=0 ; Rn=1 ; Rd=31] --> OK
-0x1ac10be0: [sf=0 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Not_found
-0x1ac10be1: [sf=0 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Not_found
+0x1ac10be0: [sf=0 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
+0x1ac10be1: [sf=0 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
 0x1ac10bff: [sf=0 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=31] --> OK
 0x1ac10c00: [sf=0 ; Rm=1 ; o1=1 ; Rn=0 ; Rd=0] --> OK
 0x1ac10c01: [sf=0 ; Rm=1 ; o1=1 ; Rn=0 ; Rd=1] --> OK
@@ -8559,8 +8559,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x1ac10c20: [sf=0 ; Rm=1 ; o1=1 ; Rn=1 ; Rd=0] --> OK
 0x1ac10c21: [sf=0 ; Rm=1 ; o1=1 ; Rn=1 ; Rd=1] --> OK
 0x1ac10c3f: [sf=0 ; Rm=1 ; o1=1 ; Rn=1 ; Rd=31] --> OK
-0x1ac10fe0: [sf=0 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Not_found
-0x1ac10fe1: [sf=0 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Not_found
+0x1ac10fe0: [sf=0 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
+0x1ac10fe1: [sf=0 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
 0x1ac10fff: [sf=0 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=31] --> OK
 0x1adf0800: [sf=0 ; Rm=31 ; o1=0 ; Rn=0 ; Rd=0] --> OK
 0x1adf0801: [sf=0 ; Rm=31 ; o1=0 ; Rn=0 ; Rd=1] --> OK
@@ -8586,8 +8586,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x9ac00820: [sf=1 ; Rm=0 ; o1=0 ; Rn=1 ; Rd=0] --> OK
 0x9ac00821: [sf=1 ; Rm=0 ; o1=0 ; Rn=1 ; Rd=1] --> OK
 0x9ac0083f: [sf=1 ; Rm=0 ; o1=0 ; Rn=1 ; Rd=31] --> OK
-0x9ac00be0: [sf=1 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Not_found
-0x9ac00be1: [sf=1 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Not_found
+0x9ac00be0: [sf=1 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
+0x9ac00be1: [sf=1 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
 0x9ac00bff: [sf=1 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=31] --> OK
 0x9ac00c00: [sf=1 ; Rm=0 ; o1=1 ; Rn=0 ; Rd=0] --> OK
 0x9ac00c01: [sf=1 ; Rm=0 ; o1=1 ; Rn=0 ; Rd=1] --> OK
@@ -8595,8 +8595,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x9ac00c20: [sf=1 ; Rm=0 ; o1=1 ; Rn=1 ; Rd=0] --> OK
 0x9ac00c21: [sf=1 ; Rm=0 ; o1=1 ; Rn=1 ; Rd=1] --> OK
 0x9ac00c3f: [sf=1 ; Rm=0 ; o1=1 ; Rn=1 ; Rd=31] --> OK
-0x9ac00fe0: [sf=1 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Not_found
-0x9ac00fe1: [sf=1 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Not_found
+0x9ac00fe0: [sf=1 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
+0x9ac00fe1: [sf=1 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
 0x9ac00fff: [sf=1 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=31] --> OK
 0x9ac10800: [sf=1 ; Rm=1 ; o1=0 ; Rn=0 ; Rd=0] --> OK
 0x9ac10801: [sf=1 ; Rm=1 ; o1=0 ; Rn=0 ; Rd=1] --> OK
@@ -8604,8 +8604,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x9ac10820: [sf=1 ; Rm=1 ; o1=0 ; Rn=1 ; Rd=0] --> OK
 0x9ac10821: [sf=1 ; Rm=1 ; o1=0 ; Rn=1 ; Rd=1] --> OK
 0x9ac1083f: [sf=1 ; Rm=1 ; o1=0 ; Rn=1 ; Rd=31] --> OK
-0x9ac10be0: [sf=1 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Not_found
-0x9ac10be1: [sf=1 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Not_found
+0x9ac10be0: [sf=1 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
+0x9ac10be1: [sf=1 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
 0x9ac10bff: [sf=1 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=31] --> OK
 0x9ac10c00: [sf=1 ; Rm=1 ; o1=1 ; Rn=0 ; Rd=0] --> OK
 0x9ac10c01: [sf=1 ; Rm=1 ; o1=1 ; Rn=0 ; Rd=1] --> OK
@@ -8613,8 +8613,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x9ac10c20: [sf=1 ; Rm=1 ; o1=1 ; Rn=1 ; Rd=0] --> OK
 0x9ac10c21: [sf=1 ; Rm=1 ; o1=1 ; Rn=1 ; Rd=1] --> OK
 0x9ac10c3f: [sf=1 ; Rm=1 ; o1=1 ; Rn=1 ; Rd=31] --> OK
-0x9ac10fe0: [sf=1 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Not_found
-0x9ac10fe1: [sf=1 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Not_found
+0x9ac10fe0: [sf=1 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
+0x9ac10fe1: [sf=1 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
 0x9ac10fff: [sf=1 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=31] --> OK
 0x9adf0800: [sf=1 ; Rm=31 ; o1=0 ; Rn=0 ; Rd=0] --> OK
 0x9adf0801: [sf=1 ; Rm=31 ; o1=0 ; Rn=0 ; Rd=1] --> OK
@@ -8681,11 +8681,11 @@ ENCODING: aarch64_integer_arithmetic_mul_uniform_add_sub
 0x1b0087e0: [sf=0 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=0] --> OK
 0x1b0087e1: [sf=0 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=1] --> OK
 0x1b0087ff: [sf=0 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=31] --> OK
-0x1b00fc00: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> OK
-0x1b00fc01: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> OK
+0x1b00fc00: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x1b00fc01: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
 0x1b00fc1f: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=31] --> OK
-0x1b00fc20: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> OK
-0x1b00fc21: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> OK
+0x1b00fc20: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x1b00fc21: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
 0x1b00fc3f: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=31] --> OK
 0x1b00ffe0: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=0] --> OK
 0x1b00ffe1: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=1] --> OK
@@ -8735,11 +8735,11 @@ ENCODING: aarch64_integer_arithmetic_mul_uniform_add_sub
 0x1b0187e0: [sf=0 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=0] --> OK
 0x1b0187e1: [sf=0 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=1] --> OK
 0x1b0187ff: [sf=0 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=31] --> OK
-0x1b01fc00: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> OK
-0x1b01fc01: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> OK
+0x1b01fc00: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x1b01fc01: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
 0x1b01fc1f: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=31] --> OK
-0x1b01fc20: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> OK
-0x1b01fc21: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> OK
+0x1b01fc20: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x1b01fc21: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
 0x1b01fc3f: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=31] --> OK
 0x1b01ffe0: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=0] --> OK
 0x1b01ffe1: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=1] --> OK
@@ -8843,11 +8843,11 @@ ENCODING: aarch64_integer_arithmetic_mul_uniform_add_sub
 0x9b0087e0: [sf=1 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=0] --> OK
 0x9b0087e1: [sf=1 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=1] --> OK
 0x9b0087ff: [sf=1 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=31] --> OK
-0x9b00fc00: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> OK
-0x9b00fc01: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> OK
+0x9b00fc00: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
+0x9b00fc01: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
 0x9b00fc1f: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=31] --> OK
-0x9b00fc20: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> OK
-0x9b00fc21: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> OK
+0x9b00fc20: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
+0x9b00fc21: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
 0x9b00fc3f: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=31] --> OK
 0x9b00ffe0: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=0] --> OK
 0x9b00ffe1: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=1] --> OK
@@ -8897,11 +8897,11 @@ ENCODING: aarch64_integer_arithmetic_mul_uniform_add_sub
 0x9b0187e0: [sf=1 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=0] --> OK
 0x9b0187e1: [sf=1 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=1] --> OK
 0x9b0187ff: [sf=1 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=31] --> OK
-0x9b01fc00: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> OK
-0x9b01fc01: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> OK
+0x9b01fc00: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
+0x9b01fc01: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
 0x9b01fc1f: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=31] --> OK
-0x9b01fc20: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> OK
-0x9b01fc21: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> OK
+0x9b01fc20: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
+0x9b01fc21: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
 0x9b01fc3f: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=31] --> OK
 0x9b01ffe0: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=0] --> OK
 0x9b01ffe1: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=1] --> OK
@@ -9169,11 +9169,11 @@ ENCODING: aarch64_integer_arithmetic_mul_widening_32_64
 0x9ba087e0: [U=1 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=0] --> OK
 0x9ba087e1: [U=1 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=1] --> OK
 0x9ba087ff: [U=1 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=31] --> OK
-0x9ba0fc00: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> OK
-0x9ba0fc01: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> OK
+0x9ba0fc00: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x9ba0fc01: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
 0x9ba0fc1f: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=31] --> OK
-0x9ba0fc20: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> OK
-0x9ba0fc21: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> OK
+0x9ba0fc20: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x9ba0fc21: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
 0x9ba0fc3f: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=31] --> OK
 0x9ba0ffe0: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=0] --> OK
 0x9ba0ffe1: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=1] --> OK
@@ -9223,11 +9223,11 @@ ENCODING: aarch64_integer_arithmetic_mul_widening_32_64
 0x9ba187e0: [U=1 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=0] --> OK
 0x9ba187e1: [U=1 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=1] --> OK
 0x9ba187ff: [U=1 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=31] --> OK
-0x9ba1fc00: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> OK
-0x9ba1fc01: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> OK
+0x9ba1fc00: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x9ba1fc01: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
 0x9ba1fc1f: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=31] --> OK
-0x9ba1fc20: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> OK
-0x9ba1fc21: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> OK
+0x9ba1fc20: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x9ba1fc21: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
 0x9ba1fc3f: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=31] --> OK
 0x9ba1ffe0: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=0] --> OK
 0x9ba1ffe1: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=1] --> OK

--- a/tests/coverage/aarch64_integer___
+++ b/tests/coverage/aarch64_integer___
@@ -105,9 +105,9 @@ ENCODING: aarch64_integer_arithmetic_add_sub_carry
 0x7a1f0020: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=1 ; Rd=0] --> OK
 0x7a1f0021: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=1 ; Rd=1] --> OK
 0x7a1f003f: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=1 ; Rd=31] --> OK
-0x7a1f03e0: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Invalid_argument("Z.log2up")
-0x7a1f03e1: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Invalid_argument("Z.log2up")
-0x7a1f03ff: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Invalid_argument("Z.log2up")
+0x7a1f03e0: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=0] --> OK
+0x7a1f03e1: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=1] --> OK
+0x7a1f03ff: [sf=0 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=31] --> OK
 0x9a000000: [sf=1 ; op=0 ; S=0 ; Rm=0 ; Rn=0 ; Rd=0] --> OK
 0x9a000001: [sf=1 ; op=0 ; S=0 ; Rm=0 ; Rn=0 ; Rd=1] --> OK
 0x9a00001f: [sf=1 ; op=0 ; S=0 ; Rm=0 ; Rn=0 ; Rd=31] --> OK
@@ -213,9 +213,9 @@ ENCODING: aarch64_integer_arithmetic_add_sub_carry
 0xfa1f0020: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=1 ; Rd=0] --> OK
 0xfa1f0021: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=1 ; Rd=1] --> OK
 0xfa1f003f: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=1 ; Rd=31] --> OK
-0xfa1f03e0: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Invalid_argument("Z.log2up")
-0xfa1f03e1: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Invalid_argument("Z.log2up")
-0xfa1f03ff: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Invalid_argument("Z.log2up")
+0xfa1f03e0: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=0] --> OK
+0xfa1f03e1: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=1] --> OK
+0xfa1f03ff: [sf=1 ; op=1 ; S=1 ; Rm=31 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_integer_arithmetic_add_sub_extendedreg
 0x0b200000: [sf=0 ; op=0 ; S=0 ; Rm=0 ; option=0 ; imm3=0 ; Rn=0 ; Rd=0] --> OK
@@ -8532,8 +8532,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x1ac00820: [sf=0 ; Rm=0 ; o1=0 ; Rn=1 ; Rd=0] --> OK
 0x1ac00821: [sf=0 ; Rm=0 ; o1=0 ; Rn=1 ; Rd=1] --> OK
 0x1ac0083f: [sf=0 ; Rm=0 ; o1=0 ; Rn=1 ; Rd=31] --> OK
-0x1ac00be0: [sf=0 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
-0x1ac00be1: [sf=0 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
+0x1ac00be0: [sf=0 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=0] --> OK
+0x1ac00be1: [sf=0 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=1] --> OK
 0x1ac00bff: [sf=0 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=31] --> OK
 0x1ac00c00: [sf=0 ; Rm=0 ; o1=1 ; Rn=0 ; Rd=0] --> OK
 0x1ac00c01: [sf=0 ; Rm=0 ; o1=1 ; Rn=0 ; Rd=1] --> OK
@@ -8541,8 +8541,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x1ac00c20: [sf=0 ; Rm=0 ; o1=1 ; Rn=1 ; Rd=0] --> OK
 0x1ac00c21: [sf=0 ; Rm=0 ; o1=1 ; Rn=1 ; Rd=1] --> OK
 0x1ac00c3f: [sf=0 ; Rm=0 ; o1=1 ; Rn=1 ; Rd=31] --> OK
-0x1ac00fe0: [sf=0 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
-0x1ac00fe1: [sf=0 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
+0x1ac00fe0: [sf=0 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=0] --> OK
+0x1ac00fe1: [sf=0 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=1] --> OK
 0x1ac00fff: [sf=0 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=31] --> OK
 0x1ac10800: [sf=0 ; Rm=1 ; o1=0 ; Rn=0 ; Rd=0] --> OK
 0x1ac10801: [sf=0 ; Rm=1 ; o1=0 ; Rn=0 ; Rd=1] --> OK
@@ -8550,8 +8550,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x1ac10820: [sf=0 ; Rm=1 ; o1=0 ; Rn=1 ; Rd=0] --> OK
 0x1ac10821: [sf=0 ; Rm=1 ; o1=0 ; Rn=1 ; Rd=1] --> OK
 0x1ac1083f: [sf=0 ; Rm=1 ; o1=0 ; Rn=1 ; Rd=31] --> OK
-0x1ac10be0: [sf=0 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
-0x1ac10be1: [sf=0 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
+0x1ac10be0: [sf=0 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=0] --> OK
+0x1ac10be1: [sf=0 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=1] --> OK
 0x1ac10bff: [sf=0 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=31] --> OK
 0x1ac10c00: [sf=0 ; Rm=1 ; o1=1 ; Rn=0 ; Rd=0] --> OK
 0x1ac10c01: [sf=0 ; Rm=1 ; o1=1 ; Rn=0 ; Rd=1] --> OK
@@ -8559,8 +8559,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x1ac10c20: [sf=0 ; Rm=1 ; o1=1 ; Rn=1 ; Rd=0] --> OK
 0x1ac10c21: [sf=0 ; Rm=1 ; o1=1 ; Rn=1 ; Rd=1] --> OK
 0x1ac10c3f: [sf=0 ; Rm=1 ; o1=1 ; Rn=1 ; Rd=31] --> OK
-0x1ac10fe0: [sf=0 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
-0x1ac10fe1: [sf=0 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 32 }} ( Exp7__5 [ 0 +: 32 ] ) ) ) )")
+0x1ac10fe0: [sf=0 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=0] --> OK
+0x1ac10fe1: [sf=0 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=1] --> OK
 0x1ac10fff: [sf=0 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=31] --> OK
 0x1adf0800: [sf=0 ; Rm=31 ; o1=0 ; Rn=0 ; Rd=0] --> OK
 0x1adf0801: [sf=0 ; Rm=31 ; o1=0 ; Rn=0 ; Rd=1] --> OK
@@ -8586,8 +8586,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x9ac00820: [sf=1 ; Rm=0 ; o1=0 ; Rn=1 ; Rd=0] --> OK
 0x9ac00821: [sf=1 ; Rm=0 ; o1=0 ; Rn=1 ; Rd=1] --> OK
 0x9ac0083f: [sf=1 ; Rm=0 ; o1=0 ; Rn=1 ; Rd=31] --> OK
-0x9ac00be0: [sf=1 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
-0x9ac00be1: [sf=1 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
+0x9ac00be0: [sf=1 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=0] --> OK
+0x9ac00be1: [sf=1 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=1] --> OK
 0x9ac00bff: [sf=1 ; Rm=0 ; o1=0 ; Rn=31 ; Rd=31] --> OK
 0x9ac00c00: [sf=1 ; Rm=0 ; o1=1 ; Rn=0 ; Rd=0] --> OK
 0x9ac00c01: [sf=1 ; Rm=0 ; o1=1 ; Rn=0 ; Rd=1] --> OK
@@ -8595,8 +8595,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x9ac00c20: [sf=1 ; Rm=0 ; o1=1 ; Rn=1 ; Rd=0] --> OK
 0x9ac00c21: [sf=1 ; Rm=0 ; o1=1 ; Rn=1 ; Rd=1] --> OK
 0x9ac00c3f: [sf=1 ; Rm=0 ; o1=1 ; Rn=1 ; Rd=31] --> OK
-0x9ac00fe0: [sf=1 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
-0x9ac00fe1: [sf=1 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
+0x9ac00fe0: [sf=1 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=0] --> OK
+0x9ac00fe1: [sf=1 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=1] --> OK
 0x9ac00fff: [sf=1 ; Rm=0 ; o1=1 ; Rn=31 ; Rd=31] --> OK
 0x9ac10800: [sf=1 ; Rm=1 ; o1=0 ; Rn=0 ; Rd=0] --> OK
 0x9ac10801: [sf=1 ; Rm=1 ; o1=0 ; Rn=0 ; Rd=1] --> OK
@@ -8604,8 +8604,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x9ac10820: [sf=1 ; Rm=1 ; o1=0 ; Rn=1 ; Rd=0] --> OK
 0x9ac10821: [sf=1 ; Rm=1 ; o1=0 ; Rn=1 ; Rd=1] --> OK
 0x9ac1083f: [sf=1 ; Rm=1 ; o1=0 ; Rn=1 ; Rd=31] --> OK
-0x9ac10be0: [sf=1 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
-0x9ac10be1: [sf=1 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
+0x9ac10be0: [sf=1 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=0] --> OK
+0x9ac10be1: [sf=1 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=1] --> OK
 0x9ac10bff: [sf=1 ; Rm=1 ; o1=0 ; Rn=31 ; Rd=31] --> OK
 0x9ac10c00: [sf=1 ; Rm=1 ; o1=1 ; Rn=0 ; Rd=0] --> OK
 0x9ac10c01: [sf=1 ; Rm=1 ; o1=1 ; Rn=0 ; Rd=1] --> OK
@@ -8613,8 +8613,8 @@ ENCODING: aarch64_integer_arithmetic_div
 0x9ac10c20: [sf=1 ; Rm=1 ; o1=1 ; Rn=1 ; Rd=0] --> OK
 0x9ac10c21: [sf=1 ; Rm=1 ; o1=1 ; Rn=1 ; Rd=1] --> OK
 0x9ac10c3f: [sf=1 ; Rm=1 ; o1=1 ; Rn=1 ; Rd=31] --> OK
-0x9ac10fe0: [sf=1 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
-0x9ac10fe1: [sf=1 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled round_tozero_real.0 {{  }} ( divide_real.0 {{  }} ( 0,cvt_int_real.0 {{  }} ( cvt_bits_sint.0 {{ 64 }} ( Exp7__5 [ 0 +: 64 ] ) ) ) )")
+0x9ac10fe0: [sf=1 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=0] --> OK
+0x9ac10fe1: [sf=1 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=1] --> OK
 0x9ac10fff: [sf=1 ; Rm=1 ; o1=1 ; Rn=31 ; Rd=31] --> OK
 0x9adf0800: [sf=1 ; Rm=31 ; o1=0 ; Rn=0 ; Rd=0] --> OK
 0x9adf0801: [sf=1 ; Rm=31 ; o1=0 ; Rn=0 ; Rd=1] --> OK
@@ -8681,11 +8681,11 @@ ENCODING: aarch64_integer_arithmetic_mul_uniform_add_sub
 0x1b0087e0: [sf=0 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=0] --> OK
 0x1b0087e1: [sf=0 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=1] --> OK
 0x1b0087ff: [sf=0 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=31] --> OK
-0x1b00fc00: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
-0x1b00fc01: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x1b00fc00: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> OK
+0x1b00fc01: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> OK
 0x1b00fc1f: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=31] --> OK
-0x1b00fc20: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
-0x1b00fc21: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x1b00fc20: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> OK
+0x1b00fc21: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> OK
 0x1b00fc3f: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=31] --> OK
 0x1b00ffe0: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=0] --> OK
 0x1b00ffe1: [sf=0 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=1] --> OK
@@ -8735,11 +8735,11 @@ ENCODING: aarch64_integer_arithmetic_mul_uniform_add_sub
 0x1b0187e0: [sf=0 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=0] --> OK
 0x1b0187e1: [sf=0 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=1] --> OK
 0x1b0187ff: [sf=0 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=31] --> OK
-0x1b01fc00: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
-0x1b01fc01: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x1b01fc00: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> OK
+0x1b01fc01: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> OK
 0x1b01fc1f: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=31] --> OK
-0x1b01fc20: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
-0x1b01fc21: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x1b01fc20: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> OK
+0x1b01fc21: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> OK
 0x1b01fc3f: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=31] --> OK
 0x1b01ffe0: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=0] --> OK
 0x1b01ffe1: [sf=0 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=1] --> OK
@@ -8843,11 +8843,11 @@ ENCODING: aarch64_integer_arithmetic_mul_uniform_add_sub
 0x9b0087e0: [sf=1 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=0] --> OK
 0x9b0087e1: [sf=1 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=1] --> OK
 0x9b0087ff: [sf=1 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=31] --> OK
-0x9b00fc00: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
-0x9b00fc01: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
+0x9b00fc00: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> OK
+0x9b00fc01: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> OK
 0x9b00fc1f: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=31] --> OK
-0x9b00fc20: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
-0x9b00fc21: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
+0x9b00fc20: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> OK
+0x9b00fc21: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> OK
 0x9b00fc3f: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=31] --> OK
 0x9b00ffe0: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=0] --> OK
 0x9b00ffe1: [sf=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=1] --> OK
@@ -8897,11 +8897,11 @@ ENCODING: aarch64_integer_arithmetic_mul_uniform_add_sub
 0x9b0187e0: [sf=1 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=0] --> OK
 0x9b0187e1: [sf=1 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=1] --> OK
 0x9b0187ff: [sf=1 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=31] --> OK
-0x9b01fc00: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
-0x9b01fc01: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
+0x9b01fc00: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> OK
+0x9b01fc01: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> OK
 0x9b01fc1f: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=31] --> OK
-0x9b01fc20: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
-0x9b01fc21: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 64 }} ( Exp6__5 [ 0 +: 64 ] ),cvt_bits_uint.0 {{ 64 }} ( Exp8__5 [ 0 +: 64 ] ) ) )")
+0x9b01fc20: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> OK
+0x9b01fc21: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> OK
 0x9b01fc3f: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=31] --> OK
 0x9b01ffe0: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=0] --> OK
 0x9b01ffe1: [sf=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=1] --> OK
@@ -9169,11 +9169,11 @@ ENCODING: aarch64_integer_arithmetic_mul_widening_32_64
 0x9ba087e0: [U=1 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=0] --> OK
 0x9ba087e1: [U=1 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=1] --> OK
 0x9ba087ff: [U=1 ; Rm=0 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=31] --> OK
-0x9ba0fc00: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
-0x9ba0fc01: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x9ba0fc00: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> OK
+0x9ba0fc01: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> OK
 0x9ba0fc1f: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=31] --> OK
-0x9ba0fc20: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
-0x9ba0fc21: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x9ba0fc20: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> OK
+0x9ba0fc21: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> OK
 0x9ba0fc3f: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=31] --> OK
 0x9ba0ffe0: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=0] --> OK
 0x9ba0ffe1: [U=1 ; Rm=0 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=1] --> OK
@@ -9223,11 +9223,11 @@ ENCODING: aarch64_integer_arithmetic_mul_widening_32_64
 0x9ba187e0: [U=1 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=0] --> OK
 0x9ba187e1: [U=1 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=1] --> OK
 0x9ba187ff: [U=1 ; Rm=1 ; o0=1 ; Ra=1 ; Rn=31 ; Rd=31] --> OK
-0x9ba1fc00: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
-0x9ba1fc01: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x9ba1fc00: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=0] --> OK
+0x9ba1fc01: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=1] --> OK
 0x9ba1fc1f: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=0 ; Rd=31] --> OK
-0x9ba1fc20: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
-0x9ba1fc21: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: unhandled sub_int.0 {{  }} ( 0,mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 32 }} ( Exp6__5 [ 0 +: 32 ] ),cvt_bits_uint.0 {{ 32 }} ( Exp8__5 [ 0 +: 32 ] ) ) )")
+0x9ba1fc20: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=0] --> OK
+0x9ba1fc21: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=1] --> OK
 0x9ba1fc3f: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=1 ; Rd=31] --> OK
 0x9ba1ffe0: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=0] --> OK
 0x9ba1ffe1: [U=1 ; Rm=1 ; o0=1 ; Ra=31 ; Rn=31 ; Rd=1] --> OK

--- a/tests/coverage/aarch64_vector_arithmetic_unary___not__rbit__rev__shift__cnt__clsz___
+++ b/tests/coverage/aarch64_vector_arithmetic_unary___not__rbit__rev__shift__cnt__clsz___
@@ -1,32 +1,32 @@
 
 ENCODING: aarch64_vector_arithmetic_unary_clsz
-0x0e204800: [Q=0 ; U=0 ; size=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x0e204801: [Q=0 ; U=0 ; size=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x0e20481f: [Q=0 ; U=0 ; size=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x0e204820: [Q=0 ; U=0 ; size=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x0e204821: [Q=0 ; U=0 ; size=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x0e20483f: [Q=0 ; U=0 ; size=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x0e204be0: [Q=0 ; U=0 ; size=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x0e204be1: [Q=0 ; U=0 ; size=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x0e204bff: [Q=0 ; U=0 ; size=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x0e604800: [Q=0 ; U=0 ; size=1 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x0e604801: [Q=0 ; U=0 ; size=1 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x0e60481f: [Q=0 ; U=0 ; size=1 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x0e604820: [Q=0 ; U=0 ; size=1 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x0e604821: [Q=0 ; U=0 ; size=1 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x0e60483f: [Q=0 ; U=0 ; size=1 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x0e604be0: [Q=0 ; U=0 ; size=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x0e604be1: [Q=0 ; U=0 ; size=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x0e604bff: [Q=0 ; U=0 ; size=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x0ea04800: [Q=0 ; U=0 ; size=2 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp18__7")
-0x0ea04801: [Q=0 ; U=0 ; size=2 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp18__7")
-0x0ea0481f: [Q=0 ; U=0 ; size=2 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp18__7")
-0x0ea04820: [Q=0 ; U=0 ; size=2 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp18__7")
-0x0ea04821: [Q=0 ; U=0 ; size=2 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp18__7")
-0x0ea0483f: [Q=0 ; U=0 ; size=2 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp18__7")
-0x0ea04be0: [Q=0 ; U=0 ; size=2 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp18__7")
-0x0ea04be1: [Q=0 ; U=0 ; size=2 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp18__7")
-0x0ea04bff: [Q=0 ; U=0 ; size=2 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp18__7")
+0x0e204800: [Q=0 ; U=0 ; size=0 ; Rn=0 ; Rd=0] --> OK
+0x0e204801: [Q=0 ; U=0 ; size=0 ; Rn=0 ; Rd=1] --> OK
+0x0e20481f: [Q=0 ; U=0 ; size=0 ; Rn=0 ; Rd=31] --> OK
+0x0e204820: [Q=0 ; U=0 ; size=0 ; Rn=1 ; Rd=0] --> OK
+0x0e204821: [Q=0 ; U=0 ; size=0 ; Rn=1 ; Rd=1] --> OK
+0x0e20483f: [Q=0 ; U=0 ; size=0 ; Rn=1 ; Rd=31] --> OK
+0x0e204be0: [Q=0 ; U=0 ; size=0 ; Rn=31 ; Rd=0] --> OK
+0x0e204be1: [Q=0 ; U=0 ; size=0 ; Rn=31 ; Rd=1] --> OK
+0x0e204bff: [Q=0 ; U=0 ; size=0 ; Rn=31 ; Rd=31] --> OK
+0x0e604800: [Q=0 ; U=0 ; size=1 ; Rn=0 ; Rd=0] --> OK
+0x0e604801: [Q=0 ; U=0 ; size=1 ; Rn=0 ; Rd=1] --> OK
+0x0e60481f: [Q=0 ; U=0 ; size=1 ; Rn=0 ; Rd=31] --> OK
+0x0e604820: [Q=0 ; U=0 ; size=1 ; Rn=1 ; Rd=0] --> OK
+0x0e604821: [Q=0 ; U=0 ; size=1 ; Rn=1 ; Rd=1] --> OK
+0x0e60483f: [Q=0 ; U=0 ; size=1 ; Rn=1 ; Rd=31] --> OK
+0x0e604be0: [Q=0 ; U=0 ; size=1 ; Rn=31 ; Rd=0] --> OK
+0x0e604be1: [Q=0 ; U=0 ; size=1 ; Rn=31 ; Rd=1] --> OK
+0x0e604bff: [Q=0 ; U=0 ; size=1 ; Rn=31 ; Rd=31] --> OK
+0x0ea04800: [Q=0 ; U=0 ; size=2 ; Rn=0 ; Rd=0] --> OK
+0x0ea04801: [Q=0 ; U=0 ; size=2 ; Rn=0 ; Rd=1] --> OK
+0x0ea0481f: [Q=0 ; U=0 ; size=2 ; Rn=0 ; Rd=31] --> OK
+0x0ea04820: [Q=0 ; U=0 ; size=2 ; Rn=1 ; Rd=0] --> OK
+0x0ea04821: [Q=0 ; U=0 ; size=2 ; Rn=1 ; Rd=1] --> OK
+0x0ea0483f: [Q=0 ; U=0 ; size=2 ; Rn=1 ; Rd=31] --> OK
+0x0ea04be0: [Q=0 ; U=0 ; size=2 ; Rn=31 ; Rd=0] --> OK
+0x0ea04be1: [Q=0 ; U=0 ; size=2 ; Rn=31 ; Rd=1] --> OK
+0x0ea04bff: [Q=0 ; U=0 ; size=2 ; Rn=31 ; Rd=31] --> OK
 0x0ee04800: [Q=0 ; U=0 ; size=3 ; Rn=0 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x0ee04801: [Q=0 ; U=0 ; size=3 ; Rn=0 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x0ee0481f: [Q=0 ; U=0 ; size=3 ; Rn=0 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
@@ -36,33 +36,33 @@ ENCODING: aarch64_vector_arithmetic_unary_clsz
 0x0ee04be0: [Q=0 ; U=0 ; size=3 ; Rn=31 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x0ee04be1: [Q=0 ; U=0 ; size=3 ; Rn=31 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x0ee04bff: [Q=0 ; U=0 ; size=3 ; Rn=31 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
-0x2e204800: [Q=0 ; U=1 ; size=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x2e204801: [Q=0 ; U=1 ; size=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x2e20481f: [Q=0 ; U=1 ; size=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x2e204820: [Q=0 ; U=1 ; size=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x2e204821: [Q=0 ; U=1 ; size=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x2e20483f: [Q=0 ; U=1 ; size=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x2e204be0: [Q=0 ; U=1 ; size=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x2e204be1: [Q=0 ; U=1 ; size=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x2e204bff: [Q=0 ; U=1 ; size=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x2e604800: [Q=0 ; U=1 ; size=1 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x2e604801: [Q=0 ; U=1 ; size=1 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x2e60481f: [Q=0 ; U=1 ; size=1 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x2e604820: [Q=0 ; U=1 ; size=1 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x2e604821: [Q=0 ; U=1 ; size=1 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x2e60483f: [Q=0 ; U=1 ; size=1 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x2e604be0: [Q=0 ; U=1 ; size=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x2e604be1: [Q=0 ; U=1 ; size=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x2e604bff: [Q=0 ; U=1 ; size=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x2ea04800: [Q=0 ; U=1 ; size=2 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp16__6")
-0x2ea04801: [Q=0 ; U=1 ; size=2 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp16__6")
-0x2ea0481f: [Q=0 ; U=1 ; size=2 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp16__6")
-0x2ea04820: [Q=0 ; U=1 ; size=2 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp16__6")
-0x2ea04821: [Q=0 ; U=1 ; size=2 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp16__6")
-0x2ea0483f: [Q=0 ; U=1 ; size=2 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp16__6")
-0x2ea04be0: [Q=0 ; U=1 ; size=2 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp16__6")
-0x2ea04be1: [Q=0 ; U=1 ; size=2 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp16__6")
-0x2ea04bff: [Q=0 ; U=1 ; size=2 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp16__6")
+0x2e204800: [Q=0 ; U=1 ; size=0 ; Rn=0 ; Rd=0] --> OK
+0x2e204801: [Q=0 ; U=1 ; size=0 ; Rn=0 ; Rd=1] --> OK
+0x2e20481f: [Q=0 ; U=1 ; size=0 ; Rn=0 ; Rd=31] --> OK
+0x2e204820: [Q=0 ; U=1 ; size=0 ; Rn=1 ; Rd=0] --> OK
+0x2e204821: [Q=0 ; U=1 ; size=0 ; Rn=1 ; Rd=1] --> OK
+0x2e20483f: [Q=0 ; U=1 ; size=0 ; Rn=1 ; Rd=31] --> OK
+0x2e204be0: [Q=0 ; U=1 ; size=0 ; Rn=31 ; Rd=0] --> OK
+0x2e204be1: [Q=0 ; U=1 ; size=0 ; Rn=31 ; Rd=1] --> OK
+0x2e204bff: [Q=0 ; U=1 ; size=0 ; Rn=31 ; Rd=31] --> OK
+0x2e604800: [Q=0 ; U=1 ; size=1 ; Rn=0 ; Rd=0] --> OK
+0x2e604801: [Q=0 ; U=1 ; size=1 ; Rn=0 ; Rd=1] --> OK
+0x2e60481f: [Q=0 ; U=1 ; size=1 ; Rn=0 ; Rd=31] --> OK
+0x2e604820: [Q=0 ; U=1 ; size=1 ; Rn=1 ; Rd=0] --> OK
+0x2e604821: [Q=0 ; U=1 ; size=1 ; Rn=1 ; Rd=1] --> OK
+0x2e60483f: [Q=0 ; U=1 ; size=1 ; Rn=1 ; Rd=31] --> OK
+0x2e604be0: [Q=0 ; U=1 ; size=1 ; Rn=31 ; Rd=0] --> OK
+0x2e604be1: [Q=0 ; U=1 ; size=1 ; Rn=31 ; Rd=1] --> OK
+0x2e604bff: [Q=0 ; U=1 ; size=1 ; Rn=31 ; Rd=31] --> OK
+0x2ea04800: [Q=0 ; U=1 ; size=2 ; Rn=0 ; Rd=0] --> OK
+0x2ea04801: [Q=0 ; U=1 ; size=2 ; Rn=0 ; Rd=1] --> OK
+0x2ea0481f: [Q=0 ; U=1 ; size=2 ; Rn=0 ; Rd=31] --> OK
+0x2ea04820: [Q=0 ; U=1 ; size=2 ; Rn=1 ; Rd=0] --> OK
+0x2ea04821: [Q=0 ; U=1 ; size=2 ; Rn=1 ; Rd=1] --> OK
+0x2ea0483f: [Q=0 ; U=1 ; size=2 ; Rn=1 ; Rd=31] --> OK
+0x2ea04be0: [Q=0 ; U=1 ; size=2 ; Rn=31 ; Rd=0] --> OK
+0x2ea04be1: [Q=0 ; U=1 ; size=2 ; Rn=31 ; Rd=1] --> OK
+0x2ea04bff: [Q=0 ; U=1 ; size=2 ; Rn=31 ; Rd=31] --> OK
 0x2ee04800: [Q=0 ; U=1 ; size=3 ; Rn=0 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x2ee04801: [Q=0 ; U=1 ; size=3 ; Rn=0 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x2ee0481f: [Q=0 ; U=1 ; size=3 ; Rn=0 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
@@ -72,33 +72,33 @@ ENCODING: aarch64_vector_arithmetic_unary_clsz
 0x2ee04be0: [Q=0 ; U=1 ; size=3 ; Rn=31 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x2ee04be1: [Q=0 ; U=1 ; size=3 ; Rn=31 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x2ee04bff: [Q=0 ; U=1 ; size=3 ; Rn=31 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
-0x4e204800: [Q=1 ; U=0 ; size=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp102__7")
-0x4e204801: [Q=1 ; U=0 ; size=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp102__7")
-0x4e20481f: [Q=1 ; U=0 ; size=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp102__7")
-0x4e204820: [Q=1 ; U=0 ; size=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp102__7")
-0x4e204821: [Q=1 ; U=0 ; size=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp102__7")
-0x4e20483f: [Q=1 ; U=0 ; size=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp102__7")
-0x4e204be0: [Q=1 ; U=0 ; size=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp102__7")
-0x4e204be1: [Q=1 ; U=0 ; size=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp102__7")
-0x4e204bff: [Q=1 ; U=0 ; size=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp102__7")
-0x4e604800: [Q=1 ; U=0 ; size=1 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x4e604801: [Q=1 ; U=0 ; size=1 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x4e60481f: [Q=1 ; U=0 ; size=1 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x4e604820: [Q=1 ; U=0 ; size=1 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x4e604821: [Q=1 ; U=0 ; size=1 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x4e60483f: [Q=1 ; U=0 ; size=1 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x4e604be0: [Q=1 ; U=0 ; size=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x4e604be1: [Q=1 ; U=0 ; size=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x4e604bff: [Q=1 ; U=0 ; size=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp54__7")
-0x4ea04800: [Q=1 ; U=0 ; size=2 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x4ea04801: [Q=1 ; U=0 ; size=2 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x4ea0481f: [Q=1 ; U=0 ; size=2 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x4ea04820: [Q=1 ; U=0 ; size=2 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x4ea04821: [Q=1 ; U=0 ; size=2 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x4ea0483f: [Q=1 ; U=0 ; size=2 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x4ea04be0: [Q=1 ; U=0 ; size=2 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x4ea04be1: [Q=1 ; U=0 ; size=2 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
-0x4ea04bff: [Q=1 ; U=0 ; size=2 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp30__7")
+0x4e204800: [Q=1 ; U=0 ; size=0 ; Rn=0 ; Rd=0] --> OK
+0x4e204801: [Q=1 ; U=0 ; size=0 ; Rn=0 ; Rd=1] --> OK
+0x4e20481f: [Q=1 ; U=0 ; size=0 ; Rn=0 ; Rd=31] --> OK
+0x4e204820: [Q=1 ; U=0 ; size=0 ; Rn=1 ; Rd=0] --> OK
+0x4e204821: [Q=1 ; U=0 ; size=0 ; Rn=1 ; Rd=1] --> OK
+0x4e20483f: [Q=1 ; U=0 ; size=0 ; Rn=1 ; Rd=31] --> OK
+0x4e204be0: [Q=1 ; U=0 ; size=0 ; Rn=31 ; Rd=0] --> OK
+0x4e204be1: [Q=1 ; U=0 ; size=0 ; Rn=31 ; Rd=1] --> OK
+0x4e204bff: [Q=1 ; U=0 ; size=0 ; Rn=31 ; Rd=31] --> OK
+0x4e604800: [Q=1 ; U=0 ; size=1 ; Rn=0 ; Rd=0] --> OK
+0x4e604801: [Q=1 ; U=0 ; size=1 ; Rn=0 ; Rd=1] --> OK
+0x4e60481f: [Q=1 ; U=0 ; size=1 ; Rn=0 ; Rd=31] --> OK
+0x4e604820: [Q=1 ; U=0 ; size=1 ; Rn=1 ; Rd=0] --> OK
+0x4e604821: [Q=1 ; U=0 ; size=1 ; Rn=1 ; Rd=1] --> OK
+0x4e60483f: [Q=1 ; U=0 ; size=1 ; Rn=1 ; Rd=31] --> OK
+0x4e604be0: [Q=1 ; U=0 ; size=1 ; Rn=31 ; Rd=0] --> OK
+0x4e604be1: [Q=1 ; U=0 ; size=1 ; Rn=31 ; Rd=1] --> OK
+0x4e604bff: [Q=1 ; U=0 ; size=1 ; Rn=31 ; Rd=31] --> OK
+0x4ea04800: [Q=1 ; U=0 ; size=2 ; Rn=0 ; Rd=0] --> OK
+0x4ea04801: [Q=1 ; U=0 ; size=2 ; Rn=0 ; Rd=1] --> OK
+0x4ea0481f: [Q=1 ; U=0 ; size=2 ; Rn=0 ; Rd=31] --> OK
+0x4ea04820: [Q=1 ; U=0 ; size=2 ; Rn=1 ; Rd=0] --> OK
+0x4ea04821: [Q=1 ; U=0 ; size=2 ; Rn=1 ; Rd=1] --> OK
+0x4ea0483f: [Q=1 ; U=0 ; size=2 ; Rn=1 ; Rd=31] --> OK
+0x4ea04be0: [Q=1 ; U=0 ; size=2 ; Rn=31 ; Rd=0] --> OK
+0x4ea04be1: [Q=1 ; U=0 ; size=2 ; Rn=31 ; Rd=1] --> OK
+0x4ea04bff: [Q=1 ; U=0 ; size=2 ; Rn=31 ; Rd=31] --> OK
 0x4ee04800: [Q=1 ; U=0 ; size=3 ; Rn=0 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x4ee04801: [Q=1 ; U=0 ; size=3 ; Rn=0 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x4ee0481f: [Q=1 ; U=0 ; size=3 ; Rn=0 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
@@ -108,33 +108,33 @@ ENCODING: aarch64_vector_arithmetic_unary_clsz
 0x4ee04be0: [Q=1 ; U=0 ; size=3 ; Rn=31 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x4ee04be1: [Q=1 ; U=0 ; size=3 ; Rn=31 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x4ee04bff: [Q=1 ; U=0 ; size=3 ; Rn=31 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
-0x6e204800: [Q=1 ; U=1 ; size=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp86__6")
-0x6e204801: [Q=1 ; U=1 ; size=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp86__6")
-0x6e20481f: [Q=1 ; U=1 ; size=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp86__6")
-0x6e204820: [Q=1 ; U=1 ; size=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp86__6")
-0x6e204821: [Q=1 ; U=1 ; size=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp86__6")
-0x6e20483f: [Q=1 ; U=1 ; size=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp86__6")
-0x6e204be0: [Q=1 ; U=1 ; size=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp86__6")
-0x6e204be1: [Q=1 ; U=1 ; size=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp86__6")
-0x6e204bff: [Q=1 ; U=1 ; size=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp86__6")
-0x6e604800: [Q=1 ; U=1 ; size=1 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x6e604801: [Q=1 ; U=1 ; size=1 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x6e60481f: [Q=1 ; U=1 ; size=1 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x6e604820: [Q=1 ; U=1 ; size=1 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x6e604821: [Q=1 ; U=1 ; size=1 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x6e60483f: [Q=1 ; U=1 ; size=1 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x6e604be0: [Q=1 ; U=1 ; size=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x6e604be1: [Q=1 ; U=1 ; size=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x6e604bff: [Q=1 ; U=1 ; size=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp46__6")
-0x6ea04800: [Q=1 ; U=1 ; size=2 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x6ea04801: [Q=1 ; U=1 ; size=2 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x6ea0481f: [Q=1 ; U=1 ; size=2 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x6ea04820: [Q=1 ; U=1 ; size=2 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x6ea04821: [Q=1 ; U=1 ; size=2 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x6ea0483f: [Q=1 ; U=1 ; size=2 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x6ea04be0: [Q=1 ; U=1 ; size=2 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x6ea04be1: [Q=1 ; U=1 ; size=2 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
-0x6ea04bff: [Q=1 ; U=1 ; size=2 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp26__6")
+0x6e204800: [Q=1 ; U=1 ; size=0 ; Rn=0 ; Rd=0] --> OK
+0x6e204801: [Q=1 ; U=1 ; size=0 ; Rn=0 ; Rd=1] --> OK
+0x6e20481f: [Q=1 ; U=1 ; size=0 ; Rn=0 ; Rd=31] --> OK
+0x6e204820: [Q=1 ; U=1 ; size=0 ; Rn=1 ; Rd=0] --> OK
+0x6e204821: [Q=1 ; U=1 ; size=0 ; Rn=1 ; Rd=1] --> OK
+0x6e20483f: [Q=1 ; U=1 ; size=0 ; Rn=1 ; Rd=31] --> OK
+0x6e204be0: [Q=1 ; U=1 ; size=0 ; Rn=31 ; Rd=0] --> OK
+0x6e204be1: [Q=1 ; U=1 ; size=0 ; Rn=31 ; Rd=1] --> OK
+0x6e204bff: [Q=1 ; U=1 ; size=0 ; Rn=31 ; Rd=31] --> OK
+0x6e604800: [Q=1 ; U=1 ; size=1 ; Rn=0 ; Rd=0] --> OK
+0x6e604801: [Q=1 ; U=1 ; size=1 ; Rn=0 ; Rd=1] --> OK
+0x6e60481f: [Q=1 ; U=1 ; size=1 ; Rn=0 ; Rd=31] --> OK
+0x6e604820: [Q=1 ; U=1 ; size=1 ; Rn=1 ; Rd=0] --> OK
+0x6e604821: [Q=1 ; U=1 ; size=1 ; Rn=1 ; Rd=1] --> OK
+0x6e60483f: [Q=1 ; U=1 ; size=1 ; Rn=1 ; Rd=31] --> OK
+0x6e604be0: [Q=1 ; U=1 ; size=1 ; Rn=31 ; Rd=0] --> OK
+0x6e604be1: [Q=1 ; U=1 ; size=1 ; Rn=31 ; Rd=1] --> OK
+0x6e604bff: [Q=1 ; U=1 ; size=1 ; Rn=31 ; Rd=31] --> OK
+0x6ea04800: [Q=1 ; U=1 ; size=2 ; Rn=0 ; Rd=0] --> OK
+0x6ea04801: [Q=1 ; U=1 ; size=2 ; Rn=0 ; Rd=1] --> OK
+0x6ea0481f: [Q=1 ; U=1 ; size=2 ; Rn=0 ; Rd=31] --> OK
+0x6ea04820: [Q=1 ; U=1 ; size=2 ; Rn=1 ; Rd=0] --> OK
+0x6ea04821: [Q=1 ; U=1 ; size=2 ; Rn=1 ; Rd=1] --> OK
+0x6ea0483f: [Q=1 ; U=1 ; size=2 ; Rn=1 ; Rd=31] --> OK
+0x6ea04be0: [Q=1 ; U=1 ; size=2 ; Rn=31 ; Rd=0] --> OK
+0x6ea04be1: [Q=1 ; U=1 ; size=2 ; Rn=31 ; Rd=1] --> OK
+0x6ea04bff: [Q=1 ; U=1 ; size=2 ; Rn=31 ; Rd=31] --> OK
 0x6ee04800: [Q=1 ; U=1 ; size=3 ; Rn=0 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x6ee04801: [Q=1 ; U=1 ; size=3 ; Rn=0 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 0x6ee0481f: [Q=1 ; U=1 ; size=3 ; Rn=0 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
@@ -146,15 +146,15 @@ ENCODING: aarch64_vector_arithmetic_unary_clsz
 0x6ee04bff: [Q=1 ; U=1 ; size=3 ; Rn=31 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 62179 char 42 - line 62180 char 0)
 
 ENCODING: aarch64_vector_arithmetic_unary_cnt
-0x0e205800: [Q=0 ; size=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x0e205801: [Q=0 ; size=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x0e20581f: [Q=0 ; size=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x0e205820: [Q=0 ; size=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x0e205821: [Q=0 ; size=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x0e20583f: [Q=0 ; size=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x0e205be0: [Q=0 ; size=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x0e205be1: [Q=0 ; size=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x0e205bff: [Q=0 ; size=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
+0x0e205800: [Q=0 ; size=0 ; Rn=0 ; Rd=0] --> OK
+0x0e205801: [Q=0 ; size=0 ; Rn=0 ; Rd=1] --> OK
+0x0e20581f: [Q=0 ; size=0 ; Rn=0 ; Rd=31] --> OK
+0x0e205820: [Q=0 ; size=0 ; Rn=1 ; Rd=0] --> OK
+0x0e205821: [Q=0 ; size=0 ; Rn=1 ; Rd=1] --> OK
+0x0e20583f: [Q=0 ; size=0 ; Rn=1 ; Rd=31] --> OK
+0x0e205be0: [Q=0 ; size=0 ; Rn=31 ; Rd=0] --> OK
+0x0e205be1: [Q=0 ; size=0 ; Rn=31 ; Rd=1] --> OK
+0x0e205bff: [Q=0 ; size=0 ; Rn=31 ; Rd=31] --> OK
 0x0e605800: [Q=0 ; size=1 ; Rn=0 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 72683 char 42 - line 72684 char 0)
 0x0e605801: [Q=0 ; size=1 ; Rn=0 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 72683 char 42 - line 72684 char 0)
 0x0e60581f: [Q=0 ; size=1 ; Rn=0 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 72683 char 42 - line 72684 char 0)
@@ -182,15 +182,15 @@ ENCODING: aarch64_vector_arithmetic_unary_cnt
 0x0ee05be0: [Q=0 ; size=3 ; Rn=31 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 72683 char 42 - line 72684 char 0)
 0x0ee05be1: [Q=0 ; size=3 ; Rn=31 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 72683 char 42 - line 72684 char 0)
 0x0ee05bff: [Q=0 ; size=3 ; Rn=31 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 72683 char 42 - line 72684 char 0)
-0x4e205800: [Q=1 ; size=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x4e205801: [Q=1 ; size=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x4e20581f: [Q=1 ; size=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x4e205820: [Q=1 ; size=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x4e205821: [Q=1 ; size=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x4e20583f: [Q=1 ; size=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x4e205be0: [Q=1 ; size=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x4e205be1: [Q=1 ; size=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
-0x4e205bff: [Q=1 ; size=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("bits_size_of_expr: no type known for Exp7__5")
+0x4e205800: [Q=1 ; size=0 ; Rn=0 ; Rd=0] --> OK
+0x4e205801: [Q=1 ; size=0 ; Rn=0 ; Rd=1] --> OK
+0x4e20581f: [Q=1 ; size=0 ; Rn=0 ; Rd=31] --> OK
+0x4e205820: [Q=1 ; size=0 ; Rn=1 ; Rd=0] --> OK
+0x4e205821: [Q=1 ; size=0 ; Rn=1 ; Rd=1] --> OK
+0x4e20583f: [Q=1 ; size=0 ; Rn=1 ; Rd=31] --> OK
+0x4e205be0: [Q=1 ; size=0 ; Rn=31 ; Rd=0] --> OK
+0x4e205be1: [Q=1 ; size=0 ; Rn=31 ; Rd=1] --> OK
+0x4e205bff: [Q=1 ; size=0 ; Rn=31 ; Rd=31] --> OK
 0x4e605800: [Q=1 ; size=1 ; Rn=0 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 72683 char 42 - line 72684 char 0)
 0x4e605801: [Q=1 ; size=1 ; Rn=0 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 72683 char 42 - line 72684 char 0)
 0x4e60581f: [Q=1 ; size=1 ; Rn=0 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 72683 char 42 - line 72684 char 0)


### PR DESCRIPTION
Extend the IntToBits conversion in three ways:
- Add a stateful component to track the anticipated width (and signedness) of integer variables, with a fixed point component to widen variables rather than introducing excessive slices
- Add a range analysis to improve the precision of the required bit-vectors widths
- Convert into either signed or unsigned bit-vector expressions based on the range analysis results

Has a slightly different approach to the existing pass, as it first walks the AST to identify the roots of integer expression and then converts the entire integer expression to a bit-vector equivalent in one go. 
Should resolve all `bits_size_of_expr` issues in the coverage test and produces slightly more compact IR.