### PR TITLE
lump NZCV cleanup with CSE

### DIFF
--- a/libASL/primops.ml
+++ b/libASL/primops.ml
@@ -140,6 +140,11 @@ let mkBits2 (n1: int) (n2: int) (v: bigint): bitvector = (
     { n = n1; v = z_extract v 0 n1 }
 )
 
+(* bool/bv converter primops *)
+let prim_cvt_bv_bool (x: bitvector): bool = x.v = Z.one
+
+let prim_cvt_bool_bv (x: bool): bitvector = if x then (mkBits 1 Z.one) else (mkBits 1 Z.zero)
+
 let prim_length_bits (x: bitvector): int = x.n
 
 let prim_cvt_int_bits (n: bigint) (i: bigint): bitvector = (

--- a/libASL/transforms.ml
+++ b/libASL/transforms.ml
@@ -281,6 +281,7 @@ module IntToBits = struct
     match e with
     | Expr_TApply (fn, tes, es) ->
       (match (fn, tes, es) with
+      | FIdent ("cvt_bool_bv", 0), _, _ -> 1
       | FIdent ("add_bits", 0), [Expr_LitInt n], _
       | FIdent ("sub_bits", 0), [Expr_LitInt n], _
       | FIdent ("mul_bits", 0), [Expr_LitInt n], _
@@ -826,6 +827,8 @@ module CommonSubExprElim = struct
       | "is_unpred_exc"      -> type_bool
       | "asl_file_open"      -> type_integer
       | "asl_file_getc"      -> type_integer
+      | "cvt_bool_bv"        -> Type_Bits(Expr_LitInt("1"))
+      | "cvt_bv_bool"        -> type_bool
       | _ -> raise (CSEError ("Can't infer type of strange primitive: " ^ (pp_expr e)))
       end
     | Expr_TApply((FIdent(name, _) | Ident(name)), [Expr_LitInt(_) as num], _) -> begin

--- a/libASL/value.ml
+++ b/libASL/value.ml
@@ -380,7 +380,7 @@ let prims_pure = [
     "cvt_bits_uint"; "in_mask"; "notin_mask"; "eq_bits"; "ne_bits"; "add_bits"; "sub_bits"; "mul_bits"; "and_bits"; "or_bits";
     "eor_bits"; "not_bits"; "zeros_bits"; "ones_bits"; "replicate_bits"; "append_bits"; "eq_str"; "ne_str"; "append_str_str";
     "cvt_int_hexstr"; "cvt_int_decstr"; "cvt_bool_str"; "cvt_bits_str"; "cvt_real_str"; "is_cunpred_exc"; "is_exctaken_exc";
-    "is_impdef_exc"; "is_see_exc"; "is_undefined_exc"; "is_unpred_exc"; "bool_of_bv"; "bv_of_bool"]
+    "is_impdef_exc"; "is_see_exc"; "is_undefined_exc"; "is_unpred_exc"; "cvt_bv_bool"; "cvt_bool_bv"]
 and prims_impure = ["ram_init"; "ram_read"; "ram_write"; "trace_memory_read"; "trace_memory_write"; "trace_event";
     "asl_file_open"; "asl_file_write"; "asl_file_getc"; "print_str"; "print_char"; "program_end"]
 

--- a/libASL/value.ml
+++ b/libASL/value.ml
@@ -363,6 +363,10 @@ let eval_prim (f: string) (tvs: value list) (vs: value list): value option =
     | "print_str" | "print_char" | "program_end") , _, _ ->
         Some (raise (EvalError (Unknown, "eval_prim: failed to invoke " ^ f ^ " {{ " ^ Utils.pp_list pp_value tvs ^ " }} ( " ^ Utils.pp_list pp_value vs ^ " )"))) *)
 
+    (* Converter primitives to reduce if-statements in instructions like `add` *)
+    | ("cvt_bv_bool",       [VInt n], [VBits({n=1; _} as x)]) -> Some (VBool (prim_cvt_bv_bool x))
+    | ("cvt_bool_bv",       [VInt n], [VBool x             ]) -> Some (VBits (prim_cvt_bool_bv x))
+
     (* No function matches *)
     | _ -> None
     )
@@ -376,7 +380,7 @@ let prims_pure = [
     "cvt_bits_uint"; "in_mask"; "notin_mask"; "eq_bits"; "ne_bits"; "add_bits"; "sub_bits"; "mul_bits"; "and_bits"; "or_bits";
     "eor_bits"; "not_bits"; "zeros_bits"; "ones_bits"; "replicate_bits"; "append_bits"; "eq_str"; "ne_str"; "append_str_str";
     "cvt_int_hexstr"; "cvt_int_decstr"; "cvt_bool_str"; "cvt_bits_str"; "cvt_real_str"; "is_cunpred_exc"; "is_exctaken_exc";
-    "is_impdef_exc"; "is_see_exc"; "is_undefined_exc"; "is_unpred_exc"]
+    "is_impdef_exc"; "is_see_exc"; "is_undefined_exc"; "is_unpred_exc"; "bool_of_bv"; "bv_of_bool"]
 and prims_impure = ["ram_init"; "ram_read"; "ram_write"; "trace_memory_read"; "trace_memory_write"; "trace_event";
     "asl_file_open"; "asl_file_write"; "asl_file_getc"; "print_str"; "print_char"; "program_end"]
 

--- a/mra_tools/arch/arch.asl
+++ b/mra_tools/arch/arch.asl
@@ -17078,9 +17078,15 @@ bits(N) VFPExpandImm(bits(8) imm8)
     integer signed_sum = SInt(x) + SInt(y) + UInt(carry_in);
     bits(N) result = unsigned_sum[N-1:0]; // same value as signed_sum[N-1:0]
     bit n = result[N-1];
-    bit z = if IsZero(result) then '1' else '0';
-    bit c = if UInt(result) == unsigned_sum then '0' else '1';
-    bit v = if SInt(result) == signed_sum then '0' else '1';
+    bit z = cvt_bool_bv(IsZero(result));
+    bit c = cvt_bool_bv(UInt(result) != unsigned_sum);
+    bit v = cvt_bool_bv(SInt(result) != signed_sum);
+
+//  original semantics:
+//  bit z = if IsZero(result) then '1' else '0';
+//  bit c = if UInt(result) == unsigned_sum then '0' else '1';
+//  bit v = if SInt(result) == signed_sum then '0' else '1';
+
     return (result, n:z:c:v);
 
 enumeration MBReqDomain    {MBReqDomain_Nonshareable, MBReqDomain_InnerShareable,

--- a/prelude.asl
+++ b/prelude.asl
@@ -82,7 +82,7 @@ __builtin bits(N)   not_bits(bits(N) x);
 __builtin bits(N)   zeros_bits();
 __builtin bits(N)   ones_bits();
 __builtin boolean   cvt_bv_bool(bit x);
-__builtin bits(N)   cvt_bool_bv(boolean x); // this needs to be bits(N), not 'bit'
+__builtin bit       cvt_bool_bv(boolean x);
 
 bits(N) add_bits_int(bits(N) x, integer y)
     return add_bits(x, cvt_int_bits(y, N));

--- a/prelude.asl
+++ b/prelude.asl
@@ -81,6 +81,8 @@ __builtin bits(N)   eor_bits(bits(N) x, bits(N) y);
 __builtin bits(N)   not_bits(bits(N) x);
 __builtin bits(N)   zeros_bits();
 __builtin bits(N)   ones_bits();
+__builtin boolean   cvt_bv_bool(bit x);
+__builtin bits(N)   cvt_bool_bv(boolean x); // this needs to be bits(N), not 'bit'
 
 bits(N) add_bits_int(bits(N) x, integer y)
     return add_bits(x, cvt_int_bits(y, N));


### PR DESCRIPTION
Combines a new primitive (`cvt_bool_bv`) into the CSE transform branch.

All in all, this branch now outputs significantly reduced semantics for arithmetic instructions, as was the original goal - e.g. the `adds` instruction loses 5 bitvector additions and 3 if-statements under these changes.