### PR TITLE
Fix comparison of RAM.

### DIFF
--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -70,7 +70,7 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
         Eval.initializeGlobals cpu.env;
     | [":init"; "regs"] ->
         let vals = (List.init 64 (fun _ -> Z.of_int64 (Random.int64 Int64.max_int))) in
-        Eval.initializeRegisters cpu.env vals;
+        Eval.initializeRegistersAndMemory cpu.env vals;
     | ":enumerate" :: iset :: tail ->
         let (start,stop,fname) = (match tail with
         | [start;stop;fname] -> (int_of_string start, int_of_string stop, fname)
@@ -105,7 +105,7 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
                 let initEnv = Eval.Env.copy cpu.env in
                 (* Obtain and set random initial values for _R registers. *)
                 let vals = (List.init 64 (fun _ -> Z.of_int64 (Random.int64 Int64.max_int))) in
-                Eval.initializeRegisters initEnv vals;
+                Eval.initializeRegistersAndMemory initEnv vals;
                 (* Replace remaining VUninitialized with default zero values. *)
                 Eval.initializeGlobals initEnv;
 

--- a/libASL/testing.ml
+++ b/libASL/testing.ml
@@ -407,7 +407,7 @@ let op_test_opcode (env: Env.t) (iset: string) (op: int): Env.t opresult =
   let initenv = Env.copy env in
   Random.self_init ();
   let vals = (List.init 64 (fun _ -> Z.of_int64 (Random.int64 Int64.max_int))) in
-  Eval.initializeRegisters initenv vals;
+  Eval.initializeRegistersAndMemory initenv vals;
   Eval.initializeGlobals initenv;
 
   let initenv = Env.freeze initenv in

--- a/tests/test_asl.ml
+++ b/tests/test_asl.ml
@@ -62,7 +62,7 @@ let test_compare env () : unit =
             (* Obtain and set random initial values for _R registers. *)
             Random.self_init ();
             let vals = (List.init 64 (fun _ -> Z.of_int64 (Random.int64 Int64.max_int))) in
-            Eval.initializeRegisters initEnv vals;
+            Eval.initializeRegistersAndMemory initEnv vals;
             (* Replace remaining VUninitialized with default zero values. *)
             Eval.initializeGlobals initEnv;
 


### PR DESCRIPTION
Deep copy mutable ram object when copying environments.
Introduce new address-dependent default value for uninitialised memory to better reveal errors (previously, all memory was 0 so addresses were indistinguishable).

(cherry picked from commit f663be43d253072d906b6df4637ba853699c4b5c)