### PR TITLE
Add basic support for floating point operations

### DIFF
--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -59,6 +59,32 @@ let () = Printexc.register_printer
         Some ("LibASL.Value.EvalError(\"" ^ e ^ "\") at " ^ pp_loc loc)
     | _ -> None)
 
+(* Don't inline these functions, as we assume their behaviours conform to some spec *)
+let no_inline = [
+  "FPConvert",0;
+  "FPRoundInt",0;
+  "FPRoundIntN",0;
+  "FPNeg",0;
+  "FPToFixed",0;
+  "FixedToFP",0;
+  "FPCompare",0;
+  "FPToFixedJS",0;
+  "FPSqrt",0;
+  "FPAdd",0;
+  "FPMul",0;
+  "FPDiv",0;
+  "FPMulAdd",0;
+  "FPMulAddH",0;
+  "FPMulX",0;
+  "FPMax",0;
+  "FPMin",0;
+  "FPMaxNum",0;
+  "FPMinNum",0;
+  "FPAbs",0;
+  "FPSub",0;
+  "FPRecpX",0;
+  "Mem.read",0;
+  "Mem.set",0]
 
 (** A variable's stack level and original identifier name.
     The "stack level" is how many scopes deep it is.
@@ -825,8 +851,7 @@ and dis_call (loc: l) (f: ident) (tes: sym list) (es: sym list): sym option rws 
 
 and dis_call' (loc: l) (f: ident) (tes: sym list) (es: sym list): sym option rws =
     let@ fn = DisEnv.getFun loc f in
-    let no_inline_impure = List.map (fun (x,y) -> FIdent (x,y)) 
-        ["Mem.read",0; "Mem.set",0] in
+    let no_inline_impure = List.map (fun (x,y) -> FIdent (x,y)) no_inline in
     (match fn with
     | Some (rty, _, targs, _, _, _) when List.mem f no_inline_impure -> 
         (* impure functions are not visited. *)
@@ -1207,24 +1232,20 @@ and dis_stmt' (x: AST.stmt): unit rws =
         | _, _ ->
             raise (DisUnsupported (loc, "for loop bounds not statically known: " ^ pp_stmt x)))
     | Stmt_Dep_Undefined loc
-    | Stmt_Undefined loc ->
-        (* We don't actually know whether this point is reachable, so we shouldn't error out *)
+    | Stmt_Undefined loc 
+    | Stmt_Unpred loc
+    | Stmt_ConstrainedUnpred loc
+    | Stmt_ImpDef (_, loc)
+    | Stmt_ExceptionTaken loc
+    | Stmt_Dep_Unpred loc
+    | Stmt_Dep_ImpDef (_, loc)
+    | Stmt_See (_, loc)
+    | Stmt_Throw (_, loc)
+    | Stmt_DecodeExecute (_, _, loc)
+    | Stmt_While (_, _, loc)
+    | Stmt_Repeat (_, _, loc)
+    | Stmt_Try (_, _, _, _, loc) ->
         DisEnv.write [Stmt_Assert(expr_false, loc)]
-    | Stmt_Unpred _
-    | Stmt_ConstrainedUnpred _
-    | Stmt_ImpDef (_, _)
-    | Stmt_ExceptionTaken _
-    | Stmt_Dep_Unpred _
-    | Stmt_Dep_ImpDef (_, _)
-    | Stmt_See (_, _)
-    | Stmt_Throw (_, _)
-    | Stmt_DecodeExecute (_, _, _)
-    | Stmt_While (_, _, _)
-    | Stmt_Repeat (_, _, _)
-    | Stmt_Try (_, _, _, _, _) ->
-        (* need to defer raising so this does not throw in unreachable cases. *)
-        let@ () = DisEnv.unit in
-        raise (DisUnsupported (stmt_loc x, "dis_stmt: unsupported statement: " ^ pp_stmt x))
     )
 
 let dis_encoding (x: encoding) (op: value): bool rws =

--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -80,7 +80,6 @@ let no_inline = [
   "FPMin",0;
   "FPMaxNum",0;
   "FPMinNum",0;
-  "FPAbs",0;
   "FPSub",0;
   "FPRecpX",0;
   "Mem.read",0;

--- a/libASL/symbolic.ml
+++ b/libASL/symbolic.ml
@@ -243,14 +243,18 @@ let sym_le_int   = prim_binop "le_int"
 let sym_eq_bits  = prim_binop "eq_bits"
 let sym_inmask   = prim_binop "in_mask"
 
+let sym_eq_real  = prim_binop "eq_real"
+
 let sym_eq (loc: AST.l) (x: sym) (y: sym): sym =
   (match (x,y) with
   | (Val x,Val y) -> Val (from_bool (eval_eq loc x y))
   | (Exp _,Val v) | (Val v, Exp _) ->
       (match v with
       | VBits _ -> sym_eq_bits loc x y
-      | VInt _ -> sym_eq_int loc x y
-      | _ -> failwith "sym_eq: unknown value type")
+      | VInt _
+      | VEnum _ -> sym_eq_int loc x y
+      | VReal _ -> sym_eq_real loc x y
+      | _ -> failwith @@ "sym_eq: unknown value type " ^ (pp_sym x) ^ " " ^ (pp_sym y))
   | (_,_) -> failwith "sym_eq: insufficient info to resolve type")
 
 (*** Symbolic Boolean Operations ***)

--- a/libASL/testing.ml
+++ b/libASL/testing.ml
@@ -333,6 +333,7 @@ let field_vals_flags_only (enc: encoding) (name: string) (wd: int): int list =
   | _ when Utils.startswith name "X" && name <> "X" -> [0;1;ones]
   | _ when Utils.startswith name "imm" -> [0;1;ones]
   | _ when Utils.startswith name "uimm" -> [1]
+  | _ when Utils.startswith name "scale" -> [0]
   | _, ("b40") -> [0;1;ones]
   | _ -> List.init bound (fun x -> x)
 

--- a/tests/coverage/aarch64_integer___
+++ b/tests/coverage/aarch64_integer___
@@ -20661,294 +20661,42 @@ ENCODING: aarch64_integer_shift_variable
 0x9adf2fff: [sf=1 ; Rm=31 ; op2=3 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_integer_tags_mcaddtag
-0x91810400: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=0 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x91810401: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=0 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181041f: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=0 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x91810420: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=1 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x91810421: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=1 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181043f: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=1 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x918107e0: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=31 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x918107e1: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=31 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x918107ff: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=31 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x91814400: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=0 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x91814401: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=0 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181441f: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=0 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x91814420: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=1 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x91814421: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=1 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181443f: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=1 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x918147e0: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=31 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x918147e1: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=31 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x918147ff: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=31 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x91818400: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=0 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x91818401: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=0 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181841f: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=0 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x91818420: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=1 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x91818421: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=1 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181843f: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=1 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x918187e0: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=31 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x918187e1: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=31 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x918187ff: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=31 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181c400: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=0 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181c401: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=0 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181c41f: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=0 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181c420: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=1 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181c421: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=1 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181c43f: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=1 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181c7e0: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=31 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181c7e1: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=31 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0x9181c7ff: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=31 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
+0x91810400: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=0 ; Xd=0] --> OK
+0x91810401: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=0 ; Xd=1] --> OK
+0x9181041f: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=0 ; Xd=31] --> OK
+0x91810420: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=1 ; Xd=0] --> OK
+0x91810421: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=1 ; Xd=1] --> OK
+0x9181043f: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=1 ; Xd=31] --> OK
+0x918107e0: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=31 ; Xd=0] --> OK
+0x918107e1: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=31 ; Xd=1] --> OK
+0x918107ff: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=31 ; Xd=31] --> OK
+0x91814400: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=0 ; Xd=0] --> OK
+0x91814401: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=0 ; Xd=1] --> OK
+0x9181441f: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=0 ; Xd=31] --> OK
+0x91814420: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=1 ; Xd=0] --> OK
+0x91814421: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=1 ; Xd=1] --> OK
+0x9181443f: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=1 ; Xd=31] --> OK
+0x918147e0: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=31 ; Xd=0] --> OK
+0x918147e1: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=31 ; Xd=1] --> OK
+0x918147ff: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=31 ; Xd=31] --> OK
+0x91818400: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=0 ; Xd=0] --> OK
+0x91818401: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=0 ; Xd=1] --> OK
+0x9181841f: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=0 ; Xd=31] --> OK
+0x91818420: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=1 ; Xd=0] --> OK
+0x91818421: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=1 ; Xd=1] --> OK
+0x9181843f: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=1 ; Xd=31] --> OK
+0x918187e0: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=31 ; Xd=0] --> OK
+0x918187e1: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=31 ; Xd=1] --> OK
+0x918187ff: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=31 ; Xd=31] --> OK
+0x9181c400: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=0 ; Xd=0] --> OK
+0x9181c401: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=0 ; Xd=1] --> OK
+0x9181c41f: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=0 ; Xd=31] --> OK
+0x9181c420: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=1 ; Xd=0] --> OK
+0x9181c421: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=1 ; Xd=1] --> OK
+0x9181c43f: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=1 ; Xd=31] --> OK
+0x9181c7e0: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=31 ; Xd=0] --> OK
+0x9181c7e1: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=31 ; Xd=1] --> OK
+0x9181c7ff: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=31 ; Xd=31] --> OK
 
 ENCODING: aarch64_integer_tags_mcgettag
 0xd9600000: [imm9=0 ; Xn=0 ; Xt=0] --> [1] Evaluation failure: EvalError at file "./mra_tools/arch/arch.asl" line 8117 char 11 - line 8118 char 0: assertion failure
@@ -20991,114 +20739,33 @@ ENCODING: aarch64_integer_tags_mcgettagarray
 0xd9e003ff: [Xn=31 ; Xt=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 28760 char 21 - line 28761 char 0)
 
 ENCODING: aarch64_integer_tags_mcinsertrandomtag
-0x9ac01000: [Xm=0 ; Xn=0 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac01001: [Xm=0 ; Xn=0 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac0101f: [Xm=0 ; Xn=0 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac01020: [Xm=0 ; Xn=1 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac01021: [Xm=0 ; Xn=1 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac0103f: [Xm=0 ; Xn=1 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac013e0: [Xm=0 ; Xn=31 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac013e1: [Xm=0 ; Xn=31 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac013ff: [Xm=0 ; Xn=31 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac11000: [Xm=1 ; Xn=0 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac11001: [Xm=1 ; Xn=0 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac1101f: [Xm=1 ; Xn=0 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac11020: [Xm=1 ; Xn=1 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac11021: [Xm=1 ; Xn=1 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac1103f: [Xm=1 ; Xn=1 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac113e0: [Xm=1 ; Xn=31 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac113e1: [Xm=1 ; Xn=31 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9ac113ff: [Xm=1 ; Xn=31 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9adf1000: [Xm=31 ; Xn=0 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9adf1001: [Xm=31 ; Xn=0 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9adf101f: [Xm=31 ; Xn=0 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9adf1020: [Xm=31 ; Xn=1 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9adf1021: [Xm=31 ; Xn=1 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9adf103f: [Xm=31 ; Xn=1 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9adf13e0: [Xm=31 ; Xn=31 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9adf13e1: [Xm=31 ; Xn=31 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
-0x9adf13ff: [Xm=31 ; Xn=31 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14227 char 14 - line 14230 char 9: dis_stmt: unsupported statement: while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-
+0x9ac01000: [Xm=0 ; Xn=0 ; Xd=0] --> OK
+0x9ac01001: [Xm=0 ; Xn=0 ; Xd=1] --> OK
+0x9ac0101f: [Xm=0 ; Xn=0 ; Xd=31] --> OK
+0x9ac01020: [Xm=0 ; Xn=1 ; Xd=0] --> OK
+0x9ac01021: [Xm=0 ; Xn=1 ; Xd=1] --> OK
+0x9ac0103f: [Xm=0 ; Xn=1 ; Xd=31] --> OK
+0x9ac013e0: [Xm=0 ; Xn=31 ; Xd=0] --> OK
+0x9ac013e1: [Xm=0 ; Xn=31 ; Xd=1] --> OK
+0x9ac013ff: [Xm=0 ; Xn=31 ; Xd=31] --> OK
+0x9ac11000: [Xm=1 ; Xn=0 ; Xd=0] --> OK
+0x9ac11001: [Xm=1 ; Xn=0 ; Xd=1] --> OK
+0x9ac1101f: [Xm=1 ; Xn=0 ; Xd=31] --> OK
+0x9ac11020: [Xm=1 ; Xn=1 ; Xd=0] --> OK
+0x9ac11021: [Xm=1 ; Xn=1 ; Xd=1] --> OK
+0x9ac1103f: [Xm=1 ; Xn=1 ; Xd=31] --> OK
+0x9ac113e0: [Xm=1 ; Xn=31 ; Xd=0] --> OK
+0x9ac113e1: [Xm=1 ; Xn=31 ; Xd=1] --> OK
+0x9ac113ff: [Xm=1 ; Xn=31 ; Xd=31] --> OK
+0x9adf1000: [Xm=31 ; Xn=0 ; Xd=0] --> OK
+0x9adf1001: [Xm=31 ; Xn=0 ; Xd=1] --> OK
+0x9adf101f: [Xm=31 ; Xn=0 ; Xd=31] --> OK
+0x9adf1020: [Xm=31 ; Xn=1 ; Xd=0] --> OK
+0x9adf1021: [Xm=31 ; Xn=1 ; Xd=1] --> OK
+0x9adf103f: [Xm=31 ; Xn=1 ; Xd=31] --> OK
+0x9adf13e0: [Xm=31 ; Xn=31 ; Xd=0] --> OK
+0x9adf13e1: [Xm=31 ; Xn=31 ; Xd=1] --> OK
+0x9adf13ff: [Xm=31 ; Xn=31 ; Xd=31] --> OK
 
 ENCODING: aarch64_integer_tags_mcinserttagmask
 0x9ac01400: [Xm=0 ; Xn=0 ; Xd=0] --> OK
@@ -31874,291 +31541,39 @@ ENCODING: aarch64_integer_tags_mcsettagpre
 0xd93fffff: [imm9=511 ; Xn=31 ; Xt=31] --> [1] Evaluation failure: EvalError at file "./mra_tools/arch/arch_instrs.asl" line 56217 char 32 - line 56218 char 0: getFun SetTagCheckedInstruction.0
 
 ENCODING: aarch64_integer_tags_mcsubtag
-0xd1810400: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=0 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd1810401: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=0 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181041f: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=0 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd1810420: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=1 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd1810421: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=1 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181043f: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=1 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd18107e0: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=31 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd18107e1: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=31 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd18107ff: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=31 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd1814400: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=0 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd1814401: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=0 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181441f: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=0 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd1814420: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=1 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd1814421: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=1 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181443f: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=1 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd18147e0: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=31 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd18147e1: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=31 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd18147ff: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=31 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd1818400: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=0 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd1818401: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=0 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181841f: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=0 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd1818420: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=1 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd1818421: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=1 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181843f: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=1 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd18187e0: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=31 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd18187e1: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=31 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd18187ff: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=31 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181c400: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=0 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181c401: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=0 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181c41f: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=0 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181c420: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=1 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181c421: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=1 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181c43f: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=1 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181c7e0: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=31 ; Xd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181c7e1: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=31 ; Xd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
-0xd181c7ff: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=31 ; Xd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 14230 char 10 - line 14236 char 10: dis_stmt: unsupported statement: while ne_bits.0 {{ 4 }} ( offset,'0000' ) do {
-offset = sub_bits.0 {{ 4 }} ( offset,'0001' ) ;
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-while eq_bits.0 {{ add_int.0 {{  }} ( 0,1 ) }} ( exclude [ UInt.1 {{ 4 }} ( tag ) ],'1' ) do {
-tag = add_bits.0 {{ 4 }} ( tag,'0001' ) ;
-}
-}
-
+0xd1810400: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=0 ; Xd=0] --> OK
+0xd1810401: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=0 ; Xd=1] --> OK
+0xd181041f: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=0 ; Xd=31] --> OK
+0xd1810420: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=1 ; Xd=0] --> OK
+0xd1810421: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=1 ; Xd=1] --> OK
+0xd181043f: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=1 ; Xd=31] --> OK
+0xd18107e0: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=31 ; Xd=0] --> OK
+0xd18107e1: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=31 ; Xd=1] --> OK
+0xd18107ff: [uimm6=1 ; op3=0 ; uimm4=1 ; Xn=31 ; Xd=31] --> OK
+0xd1814400: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=0 ; Xd=0] --> OK
+0xd1814401: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=0 ; Xd=1] --> OK
+0xd181441f: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=0 ; Xd=31] --> OK
+0xd1814420: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=1 ; Xd=0] --> OK
+0xd1814421: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=1 ; Xd=1] --> OK
+0xd181443f: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=1 ; Xd=31] --> OK
+0xd18147e0: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=31 ; Xd=0] --> OK
+0xd18147e1: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=31 ; Xd=1] --> OK
+0xd18147ff: [uimm6=1 ; op3=1 ; uimm4=1 ; Xn=31 ; Xd=31] --> OK
+0xd1818400: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=0 ; Xd=0] --> OK
+0xd1818401: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=0 ; Xd=1] --> OK
+0xd181841f: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=0 ; Xd=31] --> OK
+0xd1818420: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=1 ; Xd=0] --> OK
+0xd1818421: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=1 ; Xd=1] --> OK
+0xd181843f: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=1 ; Xd=31] --> OK
+0xd18187e0: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=31 ; Xd=0] --> OK
+0xd18187e1: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=31 ; Xd=1] --> OK
+0xd18187ff: [uimm6=1 ; op3=2 ; uimm4=1 ; Xn=31 ; Xd=31] --> OK
+0xd181c400: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=0 ; Xd=0] --> OK
+0xd181c401: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=0 ; Xd=1] --> OK
+0xd181c41f: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=0 ; Xd=31] --> OK
+0xd181c420: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=1 ; Xd=0] --> OK
+0xd181c421: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=1 ; Xd=1] --> OK
+0xd181c43f: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=1 ; Xd=31] --> OK
+0xd181c7e0: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=31 ; Xd=0] --> OK
+0xd181c7e1: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=31 ; Xd=1] --> OK
+0xd181c7ff: [uimm6=1 ; op3=3 ; uimm4=1 ; Xn=31 ; Xd=31] --> OK

--- a/tests/coverage/aarch64_vector_arithmetic_unary_______fp_float___
+++ b/tests/coverage/aarch64_vector_arithmetic_unary_______fp_float___
@@ -2528,42 +2528,24 @@ ENCODING: aarch64_vector_arithmetic_unary_shift
 0x6ee13bff: [Q=1 ; size=3 ; Rn=31 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 77597 char 42 - line 77598 char 0)
 
 ENCODING: aarch64_vector_arithmetic_unary_special_frecpx
-0x5ea1f800: [sz=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ea1f801: [sz=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ea1f81f: [sz=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ea1f820: [sz=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ea1f821: [sz=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ea1f83f: [sz=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ea1fbe0: [sz=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ea1fbe1: [sz=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ea1fbff: [sz=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ee1f800: [sz=1 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ee1f801: [sz=1 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ee1f81f: [sz=1 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ee1f820: [sz=1 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ee1f821: [sz=1 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ee1f83f: [sz=1 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ee1fbe0: [sz=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ee1fbe1: [sz=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x5ee1fbff: [sz=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
+0x5ea1f800: [sz=0 ; Rn=0 ; Rd=0] --> OK
+0x5ea1f801: [sz=0 ; Rn=0 ; Rd=1] --> OK
+0x5ea1f81f: [sz=0 ; Rn=0 ; Rd=31] --> OK
+0x5ea1f820: [sz=0 ; Rn=1 ; Rd=0] --> OK
+0x5ea1f821: [sz=0 ; Rn=1 ; Rd=1] --> OK
+0x5ea1f83f: [sz=0 ; Rn=1 ; Rd=31] --> OK
+0x5ea1fbe0: [sz=0 ; Rn=31 ; Rd=0] --> OK
+0x5ea1fbe1: [sz=0 ; Rn=31 ; Rd=1] --> OK
+0x5ea1fbff: [sz=0 ; Rn=31 ; Rd=31] --> OK
+0x5ee1f800: [sz=1 ; Rn=0 ; Rd=0] --> OK
+0x5ee1f801: [sz=1 ; Rn=0 ; Rd=1] --> OK
+0x5ee1f81f: [sz=1 ; Rn=0 ; Rd=31] --> OK
+0x5ee1f820: [sz=1 ; Rn=1 ; Rd=0] --> OK
+0x5ee1f821: [sz=1 ; Rn=1 ; Rd=1] --> OK
+0x5ee1f83f: [sz=1 ; Rn=1 ; Rd=31] --> OK
+0x5ee1fbe0: [sz=1 ; Rn=31 ; Rd=0] --> OK
+0x5ee1fbe1: [sz=1 ; Rn=31 ; Rd=1] --> OK
+0x5ee1fbff: [sz=1 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_vector_arithmetic_unary_special_recip_int
 0x0ea1c800: [Q=0 ; sz=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("bv_of_int_expr: Unknown integer expression: fdiv_int.0 {{  }} ( add_int.0 {{  }} ( fdiv_int.0 {{  }} ( 524288,add_int.0 {{  }} ( mul_int.0 {{  }} ( cvt_bits_uint.0 {{ 9 }} ( Exp4__5 [ 23 +: 9 ] ),2 ),1 ) ),1 ),2 )")
@@ -2604,24 +2586,15 @@ ENCODING: aarch64_vector_arithmetic_unary_special_recip_int
 0x4ee1cbff: [Q=1 ; sz=1 ; Rn=31 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 88202 char 39 - line 88203 char 0)
 
 ENCODING: aarch64_vector_arithmetic_unary_special_sqrt
-0x2ea1f800: [Q=0 ; sz=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x2ea1f801: [Q=0 ; sz=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x2ea1f81f: [Q=0 ; sz=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x2ea1f820: [Q=0 ; sz=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x2ea1f821: [Q=0 ; sz=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x2ea1f83f: [Q=0 ; sz=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x2ea1fbe0: [Q=0 ; sz=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x2ea1fbe1: [Q=0 ; sz=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x2ea1fbff: [Q=0 ; sz=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
+0x2ea1f800: [Q=0 ; sz=0 ; Rn=0 ; Rd=0] --> OK
+0x2ea1f801: [Q=0 ; sz=0 ; Rn=0 ; Rd=1] --> OK
+0x2ea1f81f: [Q=0 ; sz=0 ; Rn=0 ; Rd=31] --> OK
+0x2ea1f820: [Q=0 ; sz=0 ; Rn=1 ; Rd=0] --> OK
+0x2ea1f821: [Q=0 ; sz=0 ; Rn=1 ; Rd=1] --> OK
+0x2ea1f83f: [Q=0 ; sz=0 ; Rn=1 ; Rd=31] --> OK
+0x2ea1fbe0: [Q=0 ; sz=0 ; Rn=31 ; Rd=0] --> OK
+0x2ea1fbe1: [Q=0 ; sz=0 ; Rn=31 ; Rd=1] --> OK
+0x2ea1fbff: [Q=0 ; sz=0 ; Rn=31 ; Rd=31] --> OK
 0x2ee1f800: [Q=0 ; sz=1 ; Rn=0 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 82851 char 42 - line 82852 char 0)
 0x2ee1f801: [Q=0 ; sz=1 ; Rn=0 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 82851 char 42 - line 82852 char 0)
 0x2ee1f81f: [Q=0 ; sz=1 ; Rn=0 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 82851 char 42 - line 82852 char 0)
@@ -2631,80 +2604,35 @@ ENCODING: aarch64_vector_arithmetic_unary_special_sqrt
 0x2ee1fbe0: [Q=0 ; sz=1 ; Rn=31 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 82851 char 42 - line 82852 char 0)
 0x2ee1fbe1: [Q=0 ; sz=1 ; Rn=31 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 82851 char 42 - line 82852 char 0)
 0x2ee1fbff: [Q=0 ; sz=1 ; Rn=31 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 82851 char 42 - line 82852 char 0)
-0x6ea1f800: [Q=1 ; sz=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ea1f801: [Q=1 ; sz=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ea1f81f: [Q=1 ; sz=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ea1f820: [Q=1 ; sz=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ea1f821: [Q=1 ; sz=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ea1f83f: [Q=1 ; sz=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ea1fbe0: [Q=1 ; sz=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ea1fbe1: [Q=1 ; sz=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ea1fbff: [Q=1 ; sz=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ee1f800: [Q=1 ; sz=1 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ee1f801: [Q=1 ; sz=1 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ee1f81f: [Q=1 ; sz=1 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ee1f820: [Q=1 ; sz=1 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ee1f821: [Q=1 ; sz=1 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ee1f83f: [Q=1 ; sz=1 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ee1fbe0: [Q=1 ; sz=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ee1fbe1: [Q=1 ; sz=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
-0x6ee1fbff: [Q=1 ; sz=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 9170 char 31 - line 9171 char 0: dis_stmt: unsupported statement: IMPLEMENTATION_DEFINED "floating-point trap handling" ;
-
+0x6ea1f800: [Q=1 ; sz=0 ; Rn=0 ; Rd=0] --> OK
+0x6ea1f801: [Q=1 ; sz=0 ; Rn=0 ; Rd=1] --> OK
+0x6ea1f81f: [Q=1 ; sz=0 ; Rn=0 ; Rd=31] --> OK
+0x6ea1f820: [Q=1 ; sz=0 ; Rn=1 ; Rd=0] --> OK
+0x6ea1f821: [Q=1 ; sz=0 ; Rn=1 ; Rd=1] --> OK
+0x6ea1f83f: [Q=1 ; sz=0 ; Rn=1 ; Rd=31] --> OK
+0x6ea1fbe0: [Q=1 ; sz=0 ; Rn=31 ; Rd=0] --> OK
+0x6ea1fbe1: [Q=1 ; sz=0 ; Rn=31 ; Rd=1] --> OK
+0x6ea1fbff: [Q=1 ; sz=0 ; Rn=31 ; Rd=31] --> OK
+0x6ee1f800: [Q=1 ; sz=1 ; Rn=0 ; Rd=0] --> OK
+0x6ee1f801: [Q=1 ; sz=1 ; Rn=0 ; Rd=1] --> OK
+0x6ee1f81f: [Q=1 ; sz=1 ; Rn=0 ; Rd=31] --> OK
+0x6ee1f820: [Q=1 ; sz=1 ; Rn=1 ; Rd=0] --> OK
+0x6ee1f821: [Q=1 ; sz=1 ; Rn=1 ; Rd=1] --> OK
+0x6ee1f83f: [Q=1 ; sz=1 ; Rn=1 ; Rd=31] --> OK
+0x6ee1fbe0: [Q=1 ; sz=1 ; Rn=31 ; Rd=0] --> OK
+0x6ee1fbe1: [Q=1 ; sz=1 ; Rn=31 ; Rd=1] --> OK
+0x6ee1fbff: [Q=1 ; sz=1 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_vector_arithmetic_unary_special_sqrt_est_int
-0x2ea1c800: [Q=0 ; sz=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x2ea1c801: [Q=0 ; sz=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x2ea1c81f: [Q=0 ; sz=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x2ea1c820: [Q=0 ; sz=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x2ea1c821: [Q=0 ; sz=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x2ea1c83f: [Q=0 ; sz=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x2ea1cbe0: [Q=0 ; sz=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x2ea1cbe1: [Q=0 ; sz=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x2ea1cbff: [Q=0 ; sz=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
+0x2ea1c800: [Q=0 ; sz=0 ; Rn=0 ; Rd=0] --> OK
+0x2ea1c801: [Q=0 ; sz=0 ; Rn=0 ; Rd=1] --> OK
+0x2ea1c81f: [Q=0 ; sz=0 ; Rn=0 ; Rd=31] --> OK
+0x2ea1c820: [Q=0 ; sz=0 ; Rn=1 ; Rd=0] --> OK
+0x2ea1c821: [Q=0 ; sz=0 ; Rn=1 ; Rd=1] --> OK
+0x2ea1c83f: [Q=0 ; sz=0 ; Rn=1 ; Rd=31] --> OK
+0x2ea1cbe0: [Q=0 ; sz=0 ; Rn=31 ; Rd=0] --> OK
+0x2ea1cbe1: [Q=0 ; sz=0 ; Rn=31 ; Rd=1] --> OK
+0x2ea1cbff: [Q=0 ; sz=0 ; Rn=31 ; Rd=31] --> OK
 0x2ee1c800: [Q=0 ; sz=1 ; Rn=0 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 29716 char 39 - line 29717 char 0)
 0x2ee1c801: [Q=0 ; sz=1 ; Rn=0 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 29716 char 39 - line 29717 char 0)
 0x2ee1c81f: [Q=0 ; sz=1 ; Rn=0 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 29716 char 39 - line 29717 char 0)
@@ -2714,42 +2642,15 @@ b = add_int.0 {{  }} ( b,1 ) ;
 0x2ee1cbe0: [Q=0 ; sz=1 ; Rn=31 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 29716 char 39 - line 29717 char 0)
 0x2ee1cbe1: [Q=0 ; sz=1 ; Rn=31 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 29716 char 39 - line 29717 char 0)
 0x2ee1cbff: [Q=0 ; sz=1 ; Rn=31 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 29716 char 39 - line 29717 char 0)
-0x6ea1c800: [Q=1 ; sz=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x6ea1c801: [Q=1 ; sz=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x6ea1c81f: [Q=1 ; sz=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x6ea1c820: [Q=1 ; sz=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x6ea1c821: [Q=1 ; sz=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x6ea1c83f: [Q=1 ; sz=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x6ea1cbe0: [Q=1 ; sz=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x6ea1cbe1: [Q=1 ; sz=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
-0x6ea1cbff: [Q=1 ; sz=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: DisUnsupported: file "./mra_tools/arch/arch.asl" line 16871 char 10 - line 16874 char 5: dis_stmt: unsupported statement: while lt_int.0 {{  }} ( mul_int.0 {{  }} ( mul_int.0 {{  }} ( a,( add_int.0 {{  }} ( b,1 ) ) ),( add_int.0 {{  }} ( b,1 ) ) ),pow_int_int.0 {{  }} ( 2,28 ) ) do {
-b = add_int.0 {{  }} ( b,1 ) ;
-}
-
+0x6ea1c800: [Q=1 ; sz=0 ; Rn=0 ; Rd=0] --> OK
+0x6ea1c801: [Q=1 ; sz=0 ; Rn=0 ; Rd=1] --> OK
+0x6ea1c81f: [Q=1 ; sz=0 ; Rn=0 ; Rd=31] --> OK
+0x6ea1c820: [Q=1 ; sz=0 ; Rn=1 ; Rd=0] --> OK
+0x6ea1c821: [Q=1 ; sz=0 ; Rn=1 ; Rd=1] --> OK
+0x6ea1c83f: [Q=1 ; sz=0 ; Rn=1 ; Rd=31] --> OK
+0x6ea1cbe0: [Q=1 ; sz=0 ; Rn=31 ; Rd=0] --> OK
+0x6ea1cbe1: [Q=1 ; sz=0 ; Rn=31 ; Rd=1] --> OK
+0x6ea1cbff: [Q=1 ; sz=0 ; Rn=31 ; Rd=31] --> OK
 0x6ee1c800: [Q=1 ; sz=1 ; Rn=0 ; Rd=0] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 29716 char 39 - line 29717 char 0)
 0x6ee1c801: [Q=1 ; sz=1 ; Rn=0 ; Rd=1] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 29716 char 39 - line 29717 char 0)
 0x6ee1c81f: [Q=1 ; sz=1 ; Rn=0 ; Rd=31] --> UNDEFINED (file "./mra_tools/arch/arch_instrs.asl" line 29716 char 39 - line 29717 char 0)


### PR DESCRIPTION
Stop inlining at an interface that looks roughly like IEEE-754 operations.
Needs some reasoning to establish clear semantics, but sufficient for current testing purposes.