### PR TITLE
Redundant Slice Cleanup

### DIFF
--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -1381,6 +1381,7 @@ let dis_decode_entry (env: Eval.Env.t) (decode: decode_case) (op: value): stmt l
     let ((),lenv',stmts) = (dis_decode_case loc decode op) env lenv in
     let stmts' = Transforms.RemoveUnused.remove_unused globals @@ stmts in
     (* let stmts' = Transforms.Bits.bitvec_conversion stmts' in *)
+    let stmts' = Transforms.RedundantSlice.do_transform stmts' in
     let stmts' = Transforms.StatefulIntToBits.run stmts' in
     let stmts' = Transforms.IntToBits.ints_to_bits stmts' in
     let stmts' = Transforms.CommonSubExprElim.do_transform stmts' in


### PR DESCRIPTION
Additional pass to identify redundant slice operations.
Also identifies cases of slices with a dynamic offset, but static width and coverts these into right shifts with static slices.