### PR TITLE
Add Atomic Operation Support

### DIFF
--- a/tests/coverage/aarch64_branch___
+++ b/tests/coverage/aarch64_branch___
@@ -314,22 +314,22 @@ ENCODING: aarch64_branch_unconditional_register
 0xd61f07ff: [Z=0 ; op=0 ; A=0 ; M=1 ; Rn=31 ; Rm=31] --> (invalid)
 0xd61f0800: [Z=0 ; op=0 ; A=1 ; M=0 ; Rn=0 ; Rm=0] --> (invalid)
 0xd61f0801: [Z=0 ; op=0 ; A=1 ; M=0 ; Rn=0 ; Rm=1] --> (invalid)
-0xd61f081f: [Z=0 ; op=0 ; A=1 ; M=0 ; Rn=0 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd61f081f: [Z=0 ; op=0 ; A=1 ; M=0 ; Rn=0 ; Rm=31] --> OK
 0xd61f0820: [Z=0 ; op=0 ; A=1 ; M=0 ; Rn=1 ; Rm=0] --> (invalid)
 0xd61f0821: [Z=0 ; op=0 ; A=1 ; M=0 ; Rn=1 ; Rm=1] --> (invalid)
-0xd61f083f: [Z=0 ; op=0 ; A=1 ; M=0 ; Rn=1 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd61f083f: [Z=0 ; op=0 ; A=1 ; M=0 ; Rn=1 ; Rm=31] --> OK
 0xd61f0be0: [Z=0 ; op=0 ; A=1 ; M=0 ; Rn=31 ; Rm=0] --> (invalid)
 0xd61f0be1: [Z=0 ; op=0 ; A=1 ; M=0 ; Rn=31 ; Rm=1] --> (invalid)
-0xd61f0bff: [Z=0 ; op=0 ; A=1 ; M=0 ; Rn=31 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd61f0bff: [Z=0 ; op=0 ; A=1 ; M=0 ; Rn=31 ; Rm=31] --> OK
 0xd61f0c00: [Z=0 ; op=0 ; A=1 ; M=1 ; Rn=0 ; Rm=0] --> (invalid)
 0xd61f0c01: [Z=0 ; op=0 ; A=1 ; M=1 ; Rn=0 ; Rm=1] --> (invalid)
-0xd61f0c1f: [Z=0 ; op=0 ; A=1 ; M=1 ; Rn=0 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd61f0c1f: [Z=0 ; op=0 ; A=1 ; M=1 ; Rn=0 ; Rm=31] --> OK
 0xd61f0c20: [Z=0 ; op=0 ; A=1 ; M=1 ; Rn=1 ; Rm=0] --> (invalid)
 0xd61f0c21: [Z=0 ; op=0 ; A=1 ; M=1 ; Rn=1 ; Rm=1] --> (invalid)
-0xd61f0c3f: [Z=0 ; op=0 ; A=1 ; M=1 ; Rn=1 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd61f0c3f: [Z=0 ; op=0 ; A=1 ; M=1 ; Rn=1 ; Rm=31] --> OK
 0xd61f0fe0: [Z=0 ; op=0 ; A=1 ; M=1 ; Rn=31 ; Rm=0] --> (invalid)
 0xd61f0fe1: [Z=0 ; op=0 ; A=1 ; M=1 ; Rn=31 ; Rm=1] --> (invalid)
-0xd61f0fff: [Z=0 ; op=0 ; A=1 ; M=1 ; Rn=31 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd61f0fff: [Z=0 ; op=0 ; A=1 ; M=1 ; Rn=31 ; Rm=31] --> OK
 0xd63f0000: [Z=0 ; op=1 ; A=0 ; M=0 ; Rn=0 ; Rm=0] --> OK
 0xd63f0001: [Z=0 ; op=1 ; A=0 ; M=0 ; Rn=0 ; Rm=1] --> (invalid)
 0xd63f001f: [Z=0 ; op=1 ; A=0 ; M=0 ; Rn=0 ; Rm=31] --> (invalid)
@@ -350,22 +350,22 @@ ENCODING: aarch64_branch_unconditional_register
 0xd63f07ff: [Z=0 ; op=1 ; A=0 ; M=1 ; Rn=31 ; Rm=31] --> (invalid)
 0xd63f0800: [Z=0 ; op=1 ; A=1 ; M=0 ; Rn=0 ; Rm=0] --> (invalid)
 0xd63f0801: [Z=0 ; op=1 ; A=1 ; M=0 ; Rn=0 ; Rm=1] --> (invalid)
-0xd63f081f: [Z=0 ; op=1 ; A=1 ; M=0 ; Rn=0 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd63f081f: [Z=0 ; op=1 ; A=1 ; M=0 ; Rn=0 ; Rm=31] --> OK
 0xd63f0820: [Z=0 ; op=1 ; A=1 ; M=0 ; Rn=1 ; Rm=0] --> (invalid)
 0xd63f0821: [Z=0 ; op=1 ; A=1 ; M=0 ; Rn=1 ; Rm=1] --> (invalid)
-0xd63f083f: [Z=0 ; op=1 ; A=1 ; M=0 ; Rn=1 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd63f083f: [Z=0 ; op=1 ; A=1 ; M=0 ; Rn=1 ; Rm=31] --> OK
 0xd63f0be0: [Z=0 ; op=1 ; A=1 ; M=0 ; Rn=31 ; Rm=0] --> (invalid)
 0xd63f0be1: [Z=0 ; op=1 ; A=1 ; M=0 ; Rn=31 ; Rm=1] --> (invalid)
-0xd63f0bff: [Z=0 ; op=1 ; A=1 ; M=0 ; Rn=31 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd63f0bff: [Z=0 ; op=1 ; A=1 ; M=0 ; Rn=31 ; Rm=31] --> OK
 0xd63f0c00: [Z=0 ; op=1 ; A=1 ; M=1 ; Rn=0 ; Rm=0] --> (invalid)
 0xd63f0c01: [Z=0 ; op=1 ; A=1 ; M=1 ; Rn=0 ; Rm=1] --> (invalid)
-0xd63f0c1f: [Z=0 ; op=1 ; A=1 ; M=1 ; Rn=0 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd63f0c1f: [Z=0 ; op=1 ; A=1 ; M=1 ; Rn=0 ; Rm=31] --> OK
 0xd63f0c20: [Z=0 ; op=1 ; A=1 ; M=1 ; Rn=1 ; Rm=0] --> (invalid)
 0xd63f0c21: [Z=0 ; op=1 ; A=1 ; M=1 ; Rn=1 ; Rm=1] --> (invalid)
-0xd63f0c3f: [Z=0 ; op=1 ; A=1 ; M=1 ; Rn=1 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd63f0c3f: [Z=0 ; op=1 ; A=1 ; M=1 ; Rn=1 ; Rm=31] --> OK
 0xd63f0fe0: [Z=0 ; op=1 ; A=1 ; M=1 ; Rn=31 ; Rm=0] --> (invalid)
 0xd63f0fe1: [Z=0 ; op=1 ; A=1 ; M=1 ; Rn=31 ; Rm=1] --> (invalid)
-0xd63f0fff: [Z=0 ; op=1 ; A=1 ; M=1 ; Rn=31 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd63f0fff: [Z=0 ; op=1 ; A=1 ; M=1 ; Rn=31 ; Rm=31] --> OK
 0xd65f0000: [Z=0 ; op=2 ; A=0 ; M=0 ; Rn=0 ; Rm=0] --> OK
 0xd65f0001: [Z=0 ; op=2 ; A=0 ; M=0 ; Rn=0 ; Rm=1] --> (invalid)
 0xd65f001f: [Z=0 ; op=2 ; A=0 ; M=0 ; Rn=0 ; Rm=31] --> (invalid)
@@ -392,7 +392,7 @@ ENCODING: aarch64_branch_unconditional_register
 0xd65f083f: [Z=0 ; op=2 ; A=1 ; M=0 ; Rn=1 ; Rm=31] --> (invalid)
 0xd65f0be0: [Z=0 ; op=2 ; A=1 ; M=0 ; Rn=31 ; Rm=0] --> (invalid)
 0xd65f0be1: [Z=0 ; op=2 ; A=1 ; M=0 ; Rn=31 ; Rm=1] --> (invalid)
-0xd65f0bff: [Z=0 ; op=2 ; A=1 ; M=0 ; Rn=31 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd65f0bff: [Z=0 ; op=2 ; A=1 ; M=0 ; Rn=31 ; Rm=31] --> OK
 0xd65f0c00: [Z=0 ; op=2 ; A=1 ; M=1 ; Rn=0 ; Rm=0] --> (invalid)
 0xd65f0c01: [Z=0 ; op=2 ; A=1 ; M=1 ; Rn=0 ; Rm=1] --> (invalid)
 0xd65f0c1f: [Z=0 ; op=2 ; A=1 ; M=1 ; Rn=0 ; Rm=31] --> (invalid)
@@ -401,7 +401,7 @@ ENCODING: aarch64_branch_unconditional_register
 0xd65f0c3f: [Z=0 ; op=2 ; A=1 ; M=1 ; Rn=1 ; Rm=31] --> (invalid)
 0xd65f0fe0: [Z=0 ; op=2 ; A=1 ; M=1 ; Rn=31 ; Rm=0] --> (invalid)
 0xd65f0fe1: [Z=0 ; op=2 ; A=1 ; M=1 ; Rn=31 ; Rm=1] --> (invalid)
-0xd65f0fff: [Z=0 ; op=2 ; A=1 ; M=1 ; Rn=31 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd65f0fff: [Z=0 ; op=2 ; A=1 ; M=1 ; Rn=31 ; Rm=31] --> OK
 0xd67f0000: [Z=0 ; op=3 ; A=0 ; M=0 ; Rn=0 ; Rm=0] --> (invalid)
 0xd67f0001: [Z=0 ; op=3 ; A=0 ; M=0 ; Rn=0 ; Rm=1] --> (invalid)
 0xd67f001f: [Z=0 ; op=3 ; A=0 ; M=0 ; Rn=0 ; Rm=31] --> (invalid)
@@ -456,24 +456,24 @@ ENCODING: aarch64_branch_unconditional_register
 0xd71f07e0: [Z=1 ; op=0 ; A=0 ; M=1 ; Rn=31 ; Rm=0] --> (invalid)
 0xd71f07e1: [Z=1 ; op=0 ; A=0 ; M=1 ; Rn=31 ; Rm=1] --> (invalid)
 0xd71f07ff: [Z=1 ; op=0 ; A=0 ; M=1 ; Rn=31 ; Rm=31] --> (invalid)
-0xd71f0800: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=0 ; Rm=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0801: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=0 ; Rm=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f081f: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=0 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0820: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=1 ; Rm=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0821: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=1 ; Rm=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f083f: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=1 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0be0: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=31 ; Rm=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0be1: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=31 ; Rm=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0bff: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=31 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0c00: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=0 ; Rm=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0c01: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=0 ; Rm=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0c1f: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=0 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0c20: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=1 ; Rm=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0c21: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=1 ; Rm=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0c3f: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=1 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0fe0: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=31 ; Rm=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0fe1: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=31 ; Rm=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd71f0fff: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=31 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd71f0800: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=0 ; Rm=0] --> OK
+0xd71f0801: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=0 ; Rm=1] --> OK
+0xd71f081f: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=0 ; Rm=31] --> OK
+0xd71f0820: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=1 ; Rm=0] --> OK
+0xd71f0821: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=1 ; Rm=1] --> OK
+0xd71f083f: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=1 ; Rm=31] --> OK
+0xd71f0be0: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=31 ; Rm=0] --> OK
+0xd71f0be1: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=31 ; Rm=1] --> OK
+0xd71f0bff: [Z=1 ; op=0 ; A=1 ; M=0 ; Rn=31 ; Rm=31] --> OK
+0xd71f0c00: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=0 ; Rm=0] --> OK
+0xd71f0c01: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=0 ; Rm=1] --> OK
+0xd71f0c1f: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=0 ; Rm=31] --> OK
+0xd71f0c20: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=1 ; Rm=0] --> OK
+0xd71f0c21: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=1 ; Rm=1] --> OK
+0xd71f0c3f: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=1 ; Rm=31] --> OK
+0xd71f0fe0: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=31 ; Rm=0] --> OK
+0xd71f0fe1: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=31 ; Rm=1] --> OK
+0xd71f0fff: [Z=1 ; op=0 ; A=1 ; M=1 ; Rn=31 ; Rm=31] --> OK
 0xd73f0000: [Z=1 ; op=1 ; A=0 ; M=0 ; Rn=0 ; Rm=0] --> (invalid)
 0xd73f0001: [Z=1 ; op=1 ; A=0 ; M=0 ; Rn=0 ; Rm=1] --> (invalid)
 0xd73f001f: [Z=1 ; op=1 ; A=0 ; M=0 ; Rn=0 ; Rm=31] --> (invalid)
@@ -492,24 +492,24 @@ ENCODING: aarch64_branch_unconditional_register
 0xd73f07e0: [Z=1 ; op=1 ; A=0 ; M=1 ; Rn=31 ; Rm=0] --> (invalid)
 0xd73f07e1: [Z=1 ; op=1 ; A=0 ; M=1 ; Rn=31 ; Rm=1] --> (invalid)
 0xd73f07ff: [Z=1 ; op=1 ; A=0 ; M=1 ; Rn=31 ; Rm=31] --> (invalid)
-0xd73f0800: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=0 ; Rm=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0801: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=0 ; Rm=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f081f: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=0 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0820: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=1 ; Rm=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0821: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=1 ; Rm=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f083f: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=1 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0be0: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=31 ; Rm=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0be1: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=31 ; Rm=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0bff: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=31 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0c00: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=0 ; Rm=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0c01: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=0 ; Rm=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0c1f: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=0 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0c20: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=1 ; Rm=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0c21: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=1 ; Rm=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0c3f: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=1 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0fe0: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=31 ; Rm=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0fe1: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=31 ; Rm=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xd73f0fff: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=31 ; Rm=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xd73f0800: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=0 ; Rm=0] --> OK
+0xd73f0801: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=0 ; Rm=1] --> OK
+0xd73f081f: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=0 ; Rm=31] --> OK
+0xd73f0820: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=1 ; Rm=0] --> OK
+0xd73f0821: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=1 ; Rm=1] --> OK
+0xd73f083f: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=1 ; Rm=31] --> OK
+0xd73f0be0: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=31 ; Rm=0] --> OK
+0xd73f0be1: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=31 ; Rm=1] --> OK
+0xd73f0bff: [Z=1 ; op=1 ; A=1 ; M=0 ; Rn=31 ; Rm=31] --> OK
+0xd73f0c00: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=0 ; Rm=0] --> OK
+0xd73f0c01: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=0 ; Rm=1] --> OK
+0xd73f0c1f: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=0 ; Rm=31] --> OK
+0xd73f0c20: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=1 ; Rm=0] --> OK
+0xd73f0c21: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=1 ; Rm=1] --> OK
+0xd73f0c3f: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=1 ; Rm=31] --> OK
+0xd73f0fe0: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=31 ; Rm=0] --> OK
+0xd73f0fe1: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=31 ; Rm=1] --> OK
+0xd73f0fff: [Z=1 ; op=1 ; A=1 ; M=1 ; Rn=31 ; Rm=31] --> OK
 0xd75f0000: [Z=1 ; op=2 ; A=0 ; M=0 ; Rn=0 ; Rm=0] --> (invalid)
 0xd75f0001: [Z=1 ; op=2 ; A=0 ; M=0 ; Rn=0 ; Rm=1] --> (invalid)
 0xd75f001f: [Z=1 ; op=2 ; A=0 ; M=0 ; Rn=0 ; Rm=31] --> (invalid)

--- a/tests/coverage/aarch64_integer___
+++ b/tests/coverage/aarch64_integer___
@@ -20123,130 +20123,130 @@ ENCODING: aarch64_integer_logical_shiftedreg
 0xeaffffff: [sf=1 ; opc=3 ; shift=3 ; N=1 ; Rm=31 ; imm6=63 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_integer_pac_autda_dp_1src
-0xdac11800: [Z=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11801: [Z=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac1181f: [Z=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11820: [Z=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11821: [Z=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac1183f: [Z=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11be0: [Z=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11be1: [Z=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11bff: [Z=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac11800: [Z=0 ; Rn=0 ; Rd=0] --> OK
+0xdac11801: [Z=0 ; Rn=0 ; Rd=1] --> OK
+0xdac1181f: [Z=0 ; Rn=0 ; Rd=31] --> OK
+0xdac11820: [Z=0 ; Rn=1 ; Rd=0] --> OK
+0xdac11821: [Z=0 ; Rn=1 ; Rd=1] --> OK
+0xdac1183f: [Z=0 ; Rn=1 ; Rd=31] --> OK
+0xdac11be0: [Z=0 ; Rn=31 ; Rd=0] --> OK
+0xdac11be1: [Z=0 ; Rn=31 ; Rd=1] --> OK
+0xdac11bff: [Z=0 ; Rn=31 ; Rd=31] --> OK
 0xdac13800: [Z=1 ; Rn=0 ; Rd=0] --> (invalid)
 0xdac13801: [Z=1 ; Rn=0 ; Rd=1] --> (invalid)
 0xdac1381f: [Z=1 ; Rn=0 ; Rd=31] --> (invalid)
 0xdac13820: [Z=1 ; Rn=1 ; Rd=0] --> (invalid)
 0xdac13821: [Z=1 ; Rn=1 ; Rd=1] --> (invalid)
 0xdac1383f: [Z=1 ; Rn=1 ; Rd=31] --> (invalid)
-0xdac13be0: [Z=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac13be1: [Z=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac13bff: [Z=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac13be0: [Z=1 ; Rn=31 ; Rd=0] --> OK
+0xdac13be1: [Z=1 ; Rn=31 ; Rd=1] --> OK
+0xdac13bff: [Z=1 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_integer_pac_autdb_dp_1src
-0xdac11c00: [Z=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11c01: [Z=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11c1f: [Z=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11c20: [Z=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11c21: [Z=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11c3f: [Z=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11fe0: [Z=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11fe1: [Z=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11fff: [Z=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac11c00: [Z=0 ; Rn=0 ; Rd=0] --> OK
+0xdac11c01: [Z=0 ; Rn=0 ; Rd=1] --> OK
+0xdac11c1f: [Z=0 ; Rn=0 ; Rd=31] --> OK
+0xdac11c20: [Z=0 ; Rn=1 ; Rd=0] --> OK
+0xdac11c21: [Z=0 ; Rn=1 ; Rd=1] --> OK
+0xdac11c3f: [Z=0 ; Rn=1 ; Rd=31] --> OK
+0xdac11fe0: [Z=0 ; Rn=31 ; Rd=0] --> OK
+0xdac11fe1: [Z=0 ; Rn=31 ; Rd=1] --> OK
+0xdac11fff: [Z=0 ; Rn=31 ; Rd=31] --> OK
 0xdac13c00: [Z=1 ; Rn=0 ; Rd=0] --> (invalid)
 0xdac13c01: [Z=1 ; Rn=0 ; Rd=1] --> (invalid)
 0xdac13c1f: [Z=1 ; Rn=0 ; Rd=31] --> (invalid)
 0xdac13c20: [Z=1 ; Rn=1 ; Rd=0] --> (invalid)
 0xdac13c21: [Z=1 ; Rn=1 ; Rd=1] --> (invalid)
 0xdac13c3f: [Z=1 ; Rn=1 ; Rd=31] --> (invalid)
-0xdac13fe0: [Z=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac13fe1: [Z=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac13fff: [Z=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac13fe0: [Z=1 ; Rn=31 ; Rd=0] --> OK
+0xdac13fe1: [Z=1 ; Rn=31 ; Rd=1] --> OK
+0xdac13fff: [Z=1 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_integer_pac_autia_dp_1src
-0xdac11000: [Z=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11001: [Z=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac1101f: [Z=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11020: [Z=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11021: [Z=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac1103f: [Z=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac113e0: [Z=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac113e1: [Z=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac113ff: [Z=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac11000: [Z=0 ; Rn=0 ; Rd=0] --> OK
+0xdac11001: [Z=0 ; Rn=0 ; Rd=1] --> OK
+0xdac1101f: [Z=0 ; Rn=0 ; Rd=31] --> OK
+0xdac11020: [Z=0 ; Rn=1 ; Rd=0] --> OK
+0xdac11021: [Z=0 ; Rn=1 ; Rd=1] --> OK
+0xdac1103f: [Z=0 ; Rn=1 ; Rd=31] --> OK
+0xdac113e0: [Z=0 ; Rn=31 ; Rd=0] --> OK
+0xdac113e1: [Z=0 ; Rn=31 ; Rd=1] --> OK
+0xdac113ff: [Z=0 ; Rn=31 ; Rd=31] --> OK
 0xdac13000: [Z=1 ; Rn=0 ; Rd=0] --> (invalid)
 0xdac13001: [Z=1 ; Rn=0 ; Rd=1] --> (invalid)
 0xdac1301f: [Z=1 ; Rn=0 ; Rd=31] --> (invalid)
 0xdac13020: [Z=1 ; Rn=1 ; Rd=0] --> (invalid)
 0xdac13021: [Z=1 ; Rn=1 ; Rd=1] --> (invalid)
 0xdac1303f: [Z=1 ; Rn=1 ; Rd=31] --> (invalid)
-0xdac133e0: [Z=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac133e1: [Z=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac133ff: [Z=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac133e0: [Z=1 ; Rn=31 ; Rd=0] --> OK
+0xdac133e1: [Z=1 ; Rn=31 ; Rd=1] --> OK
+0xdac133ff: [Z=1 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_integer_pac_autia_hint
 (encoding unused)
 
 ENCODING: aarch64_integer_pac_autib_dp_1src
-0xdac11400: [Z=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11401: [Z=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac1141f: [Z=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11420: [Z=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac11421: [Z=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac1143f: [Z=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac117e0: [Z=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac117e1: [Z=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac117ff: [Z=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac11400: [Z=0 ; Rn=0 ; Rd=0] --> OK
+0xdac11401: [Z=0 ; Rn=0 ; Rd=1] --> OK
+0xdac1141f: [Z=0 ; Rn=0 ; Rd=31] --> OK
+0xdac11420: [Z=0 ; Rn=1 ; Rd=0] --> OK
+0xdac11421: [Z=0 ; Rn=1 ; Rd=1] --> OK
+0xdac1143f: [Z=0 ; Rn=1 ; Rd=31] --> OK
+0xdac117e0: [Z=0 ; Rn=31 ; Rd=0] --> OK
+0xdac117e1: [Z=0 ; Rn=31 ; Rd=1] --> OK
+0xdac117ff: [Z=0 ; Rn=31 ; Rd=31] --> OK
 0xdac13400: [Z=1 ; Rn=0 ; Rd=0] --> (invalid)
 0xdac13401: [Z=1 ; Rn=0 ; Rd=1] --> (invalid)
 0xdac1341f: [Z=1 ; Rn=0 ; Rd=31] --> (invalid)
 0xdac13420: [Z=1 ; Rn=1 ; Rd=0] --> (invalid)
 0xdac13421: [Z=1 ; Rn=1 ; Rd=1] --> (invalid)
 0xdac1343f: [Z=1 ; Rn=1 ; Rd=31] --> (invalid)
-0xdac137e0: [Z=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac137e1: [Z=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac137ff: [Z=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac137e0: [Z=1 ; Rn=31 ; Rd=0] --> OK
+0xdac137e1: [Z=1 ; Rn=31 ; Rd=1] --> OK
+0xdac137ff: [Z=1 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_integer_pac_autib_hint
 (encoding unused)
 
 ENCODING: aarch64_integer_pac_pacda_dp_1src
-0xdac10800: [Z=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10801: [Z=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac1081f: [Z=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10820: [Z=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10821: [Z=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac1083f: [Z=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10be0: [Z=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10be1: [Z=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10bff: [Z=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac10800: [Z=0 ; Rn=0 ; Rd=0] --> OK
+0xdac10801: [Z=0 ; Rn=0 ; Rd=1] --> OK
+0xdac1081f: [Z=0 ; Rn=0 ; Rd=31] --> OK
+0xdac10820: [Z=0 ; Rn=1 ; Rd=0] --> OK
+0xdac10821: [Z=0 ; Rn=1 ; Rd=1] --> OK
+0xdac1083f: [Z=0 ; Rn=1 ; Rd=31] --> OK
+0xdac10be0: [Z=0 ; Rn=31 ; Rd=0] --> OK
+0xdac10be1: [Z=0 ; Rn=31 ; Rd=1] --> OK
+0xdac10bff: [Z=0 ; Rn=31 ; Rd=31] --> OK
 0xdac12800: [Z=1 ; Rn=0 ; Rd=0] --> (invalid)
 0xdac12801: [Z=1 ; Rn=0 ; Rd=1] --> (invalid)
 0xdac1281f: [Z=1 ; Rn=0 ; Rd=31] --> (invalid)
 0xdac12820: [Z=1 ; Rn=1 ; Rd=0] --> (invalid)
 0xdac12821: [Z=1 ; Rn=1 ; Rd=1] --> (invalid)
 0xdac1283f: [Z=1 ; Rn=1 ; Rd=31] --> (invalid)
-0xdac12be0: [Z=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac12be1: [Z=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac12bff: [Z=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac12be0: [Z=1 ; Rn=31 ; Rd=0] --> OK
+0xdac12be1: [Z=1 ; Rn=31 ; Rd=1] --> OK
+0xdac12bff: [Z=1 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_integer_pac_pacdb_dp_1src
-0xdac10c00: [Z=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10c01: [Z=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10c1f: [Z=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10c20: [Z=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10c21: [Z=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10c3f: [Z=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10fe0: [Z=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10fe1: [Z=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10fff: [Z=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac10c00: [Z=0 ; Rn=0 ; Rd=0] --> OK
+0xdac10c01: [Z=0 ; Rn=0 ; Rd=1] --> OK
+0xdac10c1f: [Z=0 ; Rn=0 ; Rd=31] --> OK
+0xdac10c20: [Z=0 ; Rn=1 ; Rd=0] --> OK
+0xdac10c21: [Z=0 ; Rn=1 ; Rd=1] --> OK
+0xdac10c3f: [Z=0 ; Rn=1 ; Rd=31] --> OK
+0xdac10fe0: [Z=0 ; Rn=31 ; Rd=0] --> OK
+0xdac10fe1: [Z=0 ; Rn=31 ; Rd=1] --> OK
+0xdac10fff: [Z=0 ; Rn=31 ; Rd=31] --> OK
 0xdac12c00: [Z=1 ; Rn=0 ; Rd=0] --> (invalid)
 0xdac12c01: [Z=1 ; Rn=0 ; Rd=1] --> (invalid)
 0xdac12c1f: [Z=1 ; Rn=0 ; Rd=31] --> (invalid)
 0xdac12c20: [Z=1 ; Rn=1 ; Rd=0] --> (invalid)
 0xdac12c21: [Z=1 ; Rn=1 ; Rd=1] --> (invalid)
 0xdac12c3f: [Z=1 ; Rn=1 ; Rd=31] --> (invalid)
-0xdac12fe0: [Z=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac12fe1: [Z=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac12fff: [Z=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac12fe0: [Z=1 ; Rn=31 ; Rd=0] --> OK
+0xdac12fe1: [Z=1 ; Rn=31 ; Rd=1] --> OK
+0xdac12fff: [Z=1 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_integer_pac_pacga_dp_2src
 0x9ac03000: [Rm=0 ; Rn=0 ; Rd=0] --> [1] Evaluation failure: LibASL.Value.Throw(ExceptionTaken) at file "./mra_tools/support/fetchdecode.asl" line 9 char 20 - line 10 char 0
@@ -20278,47 +20278,47 @@ ENCODING: aarch64_integer_pac_pacga_dp_2src
 0x9adf33ff: [Rm=31 ; Rn=31 ; Rd=31] --> [1] Evaluation failure: LibASL.Value.Throw(ExceptionTaken) at file "./mra_tools/support/fetchdecode.asl" line 9 char 20 - line 10 char 0
 
 ENCODING: aarch64_integer_pac_pacia_dp_1src
-0xdac10000: [Z=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10001: [Z=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac1001f: [Z=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10020: [Z=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10021: [Z=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac1003f: [Z=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac103e0: [Z=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac103e1: [Z=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac103ff: [Z=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac10000: [Z=0 ; Rn=0 ; Rd=0] --> OK
+0xdac10001: [Z=0 ; Rn=0 ; Rd=1] --> OK
+0xdac1001f: [Z=0 ; Rn=0 ; Rd=31] --> OK
+0xdac10020: [Z=0 ; Rn=1 ; Rd=0] --> OK
+0xdac10021: [Z=0 ; Rn=1 ; Rd=1] --> OK
+0xdac1003f: [Z=0 ; Rn=1 ; Rd=31] --> OK
+0xdac103e0: [Z=0 ; Rn=31 ; Rd=0] --> OK
+0xdac103e1: [Z=0 ; Rn=31 ; Rd=1] --> OK
+0xdac103ff: [Z=0 ; Rn=31 ; Rd=31] --> OK
 0xdac12000: [Z=1 ; Rn=0 ; Rd=0] --> (invalid)
 0xdac12001: [Z=1 ; Rn=0 ; Rd=1] --> (invalid)
 0xdac1201f: [Z=1 ; Rn=0 ; Rd=31] --> (invalid)
 0xdac12020: [Z=1 ; Rn=1 ; Rd=0] --> (invalid)
 0xdac12021: [Z=1 ; Rn=1 ; Rd=1] --> (invalid)
 0xdac1203f: [Z=1 ; Rn=1 ; Rd=31] --> (invalid)
-0xdac123e0: [Z=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac123e1: [Z=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac123ff: [Z=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac123e0: [Z=1 ; Rn=31 ; Rd=0] --> OK
+0xdac123e1: [Z=1 ; Rn=31 ; Rd=1] --> OK
+0xdac123ff: [Z=1 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_integer_pac_pacia_hint
 (encoding unused)
 
 ENCODING: aarch64_integer_pac_pacib_dp_1src
-0xdac10400: [Z=0 ; Rn=0 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10401: [Z=0 ; Rn=0 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac1041f: [Z=0 ; Rn=0 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10420: [Z=0 ; Rn=1 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac10421: [Z=0 ; Rn=1 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac1043f: [Z=0 ; Rn=1 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac107e0: [Z=0 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac107e1: [Z=0 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac107ff: [Z=0 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac10400: [Z=0 ; Rn=0 ; Rd=0] --> OK
+0xdac10401: [Z=0 ; Rn=0 ; Rd=1] --> OK
+0xdac1041f: [Z=0 ; Rn=0 ; Rd=31] --> OK
+0xdac10420: [Z=0 ; Rn=1 ; Rd=0] --> OK
+0xdac10421: [Z=0 ; Rn=1 ; Rd=1] --> OK
+0xdac1043f: [Z=0 ; Rn=1 ; Rd=31] --> OK
+0xdac107e0: [Z=0 ; Rn=31 ; Rd=0] --> OK
+0xdac107e1: [Z=0 ; Rn=31 ; Rd=1] --> OK
+0xdac107ff: [Z=0 ; Rn=31 ; Rd=31] --> OK
 0xdac12400: [Z=1 ; Rn=0 ; Rd=0] --> (invalid)
 0xdac12401: [Z=1 ; Rn=0 ; Rd=1] --> (invalid)
 0xdac1241f: [Z=1 ; Rn=0 ; Rd=31] --> (invalid)
 0xdac12420: [Z=1 ; Rn=1 ; Rd=0] --> (invalid)
 0xdac12421: [Z=1 ; Rn=1 ; Rd=1] --> (invalid)
 0xdac1243f: [Z=1 ; Rn=1 ; Rd=31] --> (invalid)
-0xdac127e0: [Z=1 ; Rn=31 ; Rd=0] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac127e1: [Z=1 ; Rn=31 ; Rd=1] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
-0xdac127ff: [Z=1 ; Rn=31 ; Rd=31] --> [2] Disassembly failure: Failure("Casting unhandled value type to expression: {.NS = 1'0', .exceptype = Exception_PACTrap, .ipaddress = 52'0000000000000000000000000000000000000000000000000000', .ipavalid = FALSE, .syndrome = 25'0000000000000000000000000', .vaddress = 64'0000000000000000000000000000000000000000000000000000000000000000'}")
+0xdac127e0: [Z=1 ; Rn=31 ; Rd=0] --> OK
+0xdac127e1: [Z=1 ; Rn=31 ; Rd=1] --> OK
+0xdac127ff: [Z=1 ; Rn=31 ; Rd=31] --> OK
 
 ENCODING: aarch64_integer_pac_pacib_hint
 (encoding unused)


### PR DESCRIPTION
Improve support for CAS and RMW operations by:
- Fixing "SCR_EL3" and "SCTLR_EL1" to 0 so that endianness is known
- Introduce primitive AtomicStart and AtomicEnd operations to denote the bounds on an atomic region
- Overwrite RMW behaviours to use simpler memory primitives