### PR TITLE
handle Type_Register in redundant slices.

### DIFF
--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -1461,7 +1461,7 @@ let dis_decode_entry (env: Eval.Env.t) ((lenv,globals): env) (decode: decode_cas
     (* List.iter (fun (v,t) -> Printf.printf ("%s:%s\n") v (pp_type t)) varentries; *)
     let stmts = flatten stmts [] in
     let stmts' = Transforms.RemoveUnused.remove_unused globals @@ stmts in
-    let stmts' = Transforms.RedundantSlice.do_transform bindings stmts' in
+    let stmts' = Transforms.RedundantSlice.do_transform Bindings.empty stmts' in
     let stmts' = Transforms.StatefulIntToBits.run stmts' in
     let stmts' = Transforms.IntToBits.ints_to_bits stmts' in
     let stmts' = Transforms.CommonSubExprElim.do_transform stmts' in


### PR DESCRIPTION
sp is given a "register" type and this wasn't handled by the redundant slice elimination which considered arrays and bitvectors.

```bash
$ echo ':sem A64 0xd10083ff' | dune exec asli                                                                                                                                                                                                         
Decoding instruction A64 d10083ff     
SP_EL0 = add_bits.0 {{ 64 }} ( add_bits.0 {{ 64 }} ( SP_EL0,'1111111111111111111111111111111111111111111111111111111111011111' ),'0000000000000000000000000000000000000000000000000000000000000001' ) ;
```

fixes #41. 