### PR TITLE
ci: use nix

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -1,0 +1,28 @@
+name: Build with opam
+
+on:
+  push:
+    branches: [ partial_eval ]
+    paths: [ '*.opam', '.github/**' ]
+  pull_request:
+    paths: [ '*.opam', '.github/**' ]
+  workflow_dispatch:
+
+# only run one instance of this action at a time.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: ocaml/setup-ocaml@v2
+      with:
+        ocaml-compiler: 4.09
+    - run: opam install dune
+    - run: opam install . --deps-only --with-test
+    - run: opam exec -- dune build --profile release
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,12 +27,6 @@ jobs:
     - uses: cachix/install-nix-action@v25
     - run: echo 'preparing nix shell environment'
 
-    # it will be nice to make this work, just in case we aslp adds new dependencies 
-    # - uses: ocaml/setup-ocaml@v2
-    #   with:
-    #     ocaml-compiler: ocaml-system.4.09.1 # must match nix develop's ocaml version!
-    # - run: opam install . --deps-only --with-test
-
     - run: dune build --profile release
     - run: ./coverage.sh test
       id: coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,38 +15,31 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    container: 
-      image: ghcr.io/uq-pac/asli-base:latest
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
+    defaults:
+      run:
+        # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+        # XXX using multi-line string will fail since \n is stuck to the end of the argument.
+        shell: "nix develop github:katrinafyi/pac-nix#ocamlPackages_pac.asli --impure --accept-flake-config --command bash --noprofile --norc -eo pipefail {0}"
+
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        
-      - name: Extract encodings
-        run: tar xzf encodings.tar.gz 
-      
-      - name: opam install
-        run: |
-          eval `opam env`
-          opam install . --deps-only --with-test
+    - uses: actions/checkout@v4
 
-      - name: Build
-        run: |
-          eval `opam env`
-          dune build
+    - uses: cachix/install-nix-action@v25
+    - run: echo 'preparing nix shell environment'
 
-      - name: Test
-        id: test
-        run: |
-          eval `opam env`
-          export LD_LIBRARY_PATH=`opam config var z3:lib`
-          ./coverage.sh test
+    # it will be nice to make this work, just in case we aslp adds new dependencies 
+    # - uses: ocaml/setup-ocaml@v2
+    #   with:
+    #     ocaml-compiler: ocaml-system.4.09.1 # must match nix develop's ocaml version!
+    # - run: opam install . --deps-only --with-test
 
-      - name: Upload new coverage results
-        if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-output-${{ github.run_id }}
-          path: ${{ steps.test.outputs.OUTPUT }}
+    - run: dune build --profile release
+    - run: ./coverage.sh test
+      id: coverage
+
+    - name: Upload new coverage results
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-output-${{ github.run_id }}
+        path: ${{ steps.coverage.outputs.OUTPUT }}

--- a/asli.opam
+++ b/asli.opam
@@ -29,6 +29,7 @@ depends: [
   "dune-site"
   "lwt"
   "cohttp-lwt-unix"
+  "yojson"
   "odoc" {with-doc}
 ]
 build: [

--- a/dune-project
+++ b/dune-project
@@ -28,6 +28,7 @@
     "dune-site"
     "lwt"
     "cohttp-lwt-unix"
+    "yojson"
   )
   (sites (share aslfiles))
 )


### PR DESCRIPTION
The current Dockerfile is unmaintained and has fallen out of date. It also never saw use as a common development environment so it's not a good base for the CI. 

This changes the aslp CI to use the now-preferred Nix environment. This has the added benefit of offering more transparency than a Docker container's binary blob.

To make sure we can still build with plain opam, it might be useful to run a weekly build with only opam/dune. This will be slow, but it would just be a sanity check.

For reference, the previous Dockerfile was here: https://github.com/katrinafyi/pac-environment