### PR TITLE
match raw pretty printing of optional_else and indented_block

### DIFF
--- a/libASL/asl.ott
+++ b/libASL/asl.ott
@@ -630,8 +630,12 @@ s_elsif :: 'S_Elsif_' ::=
 
 optional_else :: 'S_Else' ::=
     {{ phantom }} {{ ocaml stmt list }}
-    {{ pp-raw x = match x with [] -> string ""
-                             | ys -> string "(else " ^^ separate (string "\n") (List.map pp_raw_stmt ys) ^^ string ")" }}
+    {{ pp-raw x = (nest 4 (lbracket
+                          ^^ hardline
+                          ^^ (separate hardline (List.map pp_raw_stmt x))))
+                  ^^ hardline
+                  ^^ rbracket
+    }}
     {{ pp     x = match x with [] -> string ""
                              | ys -> string "else {" ^^ hardline
                                          ^^ (nest 4 (separate (string "\n") (List.map pp_stmt ys @ [string "}"])))

--- a/libASL/asl.ott
+++ b/libASL/asl.ott
@@ -630,12 +630,7 @@ s_elsif :: 'S_Elsif_' ::=
 
 optional_else :: 'S_Else' ::=
     {{ phantom }} {{ ocaml stmt list }}
-    {{ pp-raw x = (nest 4 (lbracket
-                          ^^ hardline
-                          ^^ (separate hardline (List.map pp_raw_stmt x))))
-                  ^^ hardline
-                  ^^ rbracket
-    }}
+    {{ pp-raw x = pp_raw_indented_block x }}
     {{ pp     x = match x with [] -> string ""
                              | ys -> string "else {" ^^ hardline
                                          ^^ (nest 4 (separate (string "\n") (List.map pp_stmt ys @ [string "}"])))


### PR DESCRIPTION
Currently `optional_else` AST is printed in the format `(else ...)` which
is inconsistent with the format used for other comparable blocks such as
`indented_block`.

This PR changes the format to directly invoke `pp_raw_indented_block`.