### PR TITLE
OCaml version to 4.14

### DIFF
--- a/.github/workflows/opam.yml
+++ b/.github/workflows/opam.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ocaml/setup-ocaml@v2
       with:
-        ocaml-compiler: 4.09
+        ocaml-compiler: 4.14
     - run: opam install dune
     - run: opam install . --deps-only --with-test
     - run: opam exec -- dune build --profile release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ocaml/opam:ubuntu-20.04-ocaml-4.09
+FROM ocaml/opam:ubuntu-20.04-ocaml-4.14
 
 # Install system dependencies
 USER root

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ describing how to use ASLi with Arm's v8.6-A ISA specification.
 
 To build and run the ASL interpreter, you will need:
 
-  * OCaml version 4.09 or later
+  * OCaml version 4.14 or later
   * OPAM OCaml version 2.0.5 (other versions may work)
   * The following OPAM packages
       * ocaml     - OCaml compiler

--- a/asli.opam
+++ b/asli.opam
@@ -17,7 +17,7 @@ homepage: "https://github.com/alastairreid/asl-interpreter"
 bug-reports: "https://github.com/alastairreid/asl-interpreter/issues"
 depends: [
   "dune" {>= "2.8"}
-  "ocaml" {>= "4.09"}
+  "ocaml" {>= "4.14"}
   "menhir" {build}
   "ott" {build & >= "0.31"}
   "linenoise"

--- a/dune-project
+++ b/dune-project
@@ -16,7 +16,7 @@
                "\| loading ELF files and executing Arm binaries.
   )
   (depends
-    ("ocaml"     (>= "4.09"))
+    ("ocaml"     (>= "4.14"))
     ("menhir"    :build)
     ("ott"       (and :build (>= "0.31")))
     "linenoise"


### PR DESCRIPTION
Fix up build issues introduced by #55 by bumping OCaml version up to 4.14.