### PR TITLE
gitattributes: ignore *.t and *.asl files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 *.asl   text eol=lf
 *.prj   text eol=lf
+*.t     linguist-vendored
+*.asl   linguist-vendored


### PR DESCRIPTION
this should prevent the repository from being marked as 60% raku (which uses the .t extension).

see: https://github.com/github-linguist/linguist/blob/master/docs/overrides.md
