### PR TITLE
support multiple :gen backends

### DIFF
--- a/libASL/cpu.mli
+++ b/libASL/cpu.mli
@@ -5,6 +5,12 @@
  * SPDX-Licence-Identifier: BSD-3-Clause
  ****************************************************************)
 
+type gen_backend =
+    | Ocaml
+    | Cpp
+
+type gen_function = Asl_ast.ident -> Eval.fun_sig -> Eval.fun_sig Asl_utils.Bindings.t -> Eval.fun_sig Asl_utils.Bindings.t -> string -> unit
+
 type cpu = {
     env      : Eval.Env.t;
     denv     : Dis.env;
@@ -15,7 +21,7 @@ type cpu = {
     elfwrite : Int64.t -> char -> unit;
     opcode   : string -> Primops.bigint -> unit;
     sem      : string -> Primops.bigint -> unit;
-    gen      : string -> string -> unit
+    gen      : string -> string -> gen_backend -> string -> unit;
 }
 
 val mkCPU : Eval.Env.t -> Dis.env -> cpu

--- a/libASL/eval.ml
+++ b/libASL/eval.ml
@@ -128,9 +128,9 @@ module Env : sig
     val getVar              : AST.l -> t -> ident -> value
     val setVar              : AST.l -> t -> ident -> value -> unit
 
-    val getFun              : AST.l -> t -> ident -> (ty option * ((ty * ident) list) * ident list * ident list * AST.l * stmt list)
-    val getFunOpt           : AST.l -> t -> ident -> (ty option * ((ty * ident) list) * ident list * ident list * AST.l * stmt list) option
-    val addFun              : AST.l -> t -> ident -> (ty option * ((ty * ident) list) * ident list * ident list * AST.l * stmt list) -> unit
+    val getFun              : AST.l -> t -> ident -> fun_sig
+    val getFunOpt           : AST.l -> t -> ident -> fun_sig option
+    val addFun              : AST.l -> t -> ident -> fun_sig -> unit
 
     val getInstruction      : AST.l -> t -> ident -> (encoding * (stmt list) option * bool * stmt list)
     val addInstruction      : AST.l -> t -> ident -> (encoding * (stmt list) option * bool * stmt list) -> unit


### PR DESCRIPTION
Also documents the :gen command in :help and adds support for user-specified output directories.

As an example, I've added a pattern match for a "cpp" backend which does nothing.

