### PR TITLE
gitattributes: ignore vendored aslp-cpp lib directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.prj   text eol=lf
 *.t     linguist-vendored
 *.asl   linguist-vendored
+/aslp-cpp/lib/** linguist-vendored


### PR DESCRIPTION
continuing the quest to mark the repository as OCaml and not C++.

after #61, the vendored C++ libraries now dominate the repository. this should fix that.