### PR TITLE
cram: add test case for local variable redefinition

### DIFF
--- a/tests/aslt/ops.txt
+++ b/tests/aslt/ops.txt
@@ -22,3 +22,5 @@
 // tbl v0.8b, {v0.16b}, v0.8b
 0x0e000000
 
+// cnt v0.8b, v0.8b https://github.com/UQ-PAC/aslp/issues/43
+0x0e205800

--- a/tests/aslt/test_antlr.t
+++ b/tests/aslt/test_antlr.t
@@ -86,6 +86,278 @@ tests building and running of the antlr grammar. requires java
   (stmt (assignment_stmt Stmt_Assert ( (expr Expr_TApply ( (ident " and_bool.0 ") , [ ] , [ (expr Expr_TApply ( (ident " sle_bits.0 ") , [ (targs (expr (integer 9))) ] , [ (expr (bits '000000000')) ; (expr Expr_Var ( (ident " Cse3__5 ") )) ] )) ; (expr Expr_TApply ( (ident " sle_bits.0 ") , [ (targs (expr (integer 13))) ] , [ (expr Expr_TApply ( (ident " ZeroExtend.0 ") , [ (targs (expr (integer 12))) ; (targs (expr (integer 13))) ] , [ (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 12))) ] , [ (expr Expr_TApply ( (ident " ZeroExtend.0 ") , [ (targs (expr (integer 11))) ; (targs (expr (integer 12))) ] , [ (expr Expr_TApply ( (ident " mul_bits.0 ") , [ (targs (expr (integer 11))) ] , [ (expr Expr_Var ( (ident " Cse0__5 ") )) ; (expr (bits '00000001000')) ] )) ; (expr (integer 12)) ] )) ; (expr (bits '000000001000')) ] )) ; (expr (integer 13)) ] )) ; (expr (bits '0000010000000')) ] )) ] )) ))) ;
   (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__4 ") )) , (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 8))) ; (targs (expr (integer 56))) ] , [ (expr Expr_Slices ( (expr Expr_TApply ( (ident " lsr_bits.0 ") , [ (targs (expr (integer 128))) ; (targs (expr (integer 12))) ] , [ (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) ; (expr Expr_TApply ( (ident " ZeroExtend.0 ") , [ (targs (expr (integer 11))) ; (targs (expr (integer 12))) ] , [ (expr Expr_TApply ( (ident " mul_bits.0 ") , [ (targs (expr (integer 11))) ] , [ (expr Expr_Var ( (ident " Cse0__5 ") )) ; (expr (bits '00000001000')) ] )) ; (expr (integer 12)) ] )) ] )) , [ (slice Slice_LoWd ( (expr (integer 0)) , (expr (integer 8)) )) ] )) ; (expr Expr_Slices ( (expr Expr_Var ( (ident " result__4 ") )) , [ (slice Slice_LoWd ( (expr (integer 0)) , (expr (integer 56)) )) ] )) ] )) ))) ]) , [ ] ,
   (stmts [ ]) )))
-  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Array ( (lexpr LExpr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , (expr Expr_TApply ( (ident " ZeroExtend.0 ") , [ (targs (expr (integer 64))) ; (targs (expr (integer 128))) ] , [ (expr Expr_Var ( (ident " result__4 ") )) ; (expr (integer 128)) ] )) ))) <EOF>)
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Array ( (lexpr LExpr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , (expr Expr_TApply ( (ident " ZeroExtend.0 ") , [ (targs (expr (integer 64))) ; (targs (expr (integer 128))) ] , [ (expr Expr_Var ( (ident " result__4 ") )) ; (expr (integer 128)) ] )) )))
+  (stmt (assignment_stmt Stmt_VarDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " result__5 ") , (expr (bits '0000')) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 0)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5 ") )) , (expr (bits '0001')) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 1)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 2)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 3)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 4)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 5)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 6)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 7)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (assignment_stmt Stmt_ConstDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " Exp14__5 ") , (expr Expr_Var ( (ident " result__5 ") )) )))
+  (stmt (assignment_stmt Stmt_VarDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " result__5_1 ") , (expr (bits '0000')) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 8)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_1 ") )) , (expr (bits '0001')) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 9)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_1 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_1 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 10)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_1 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_1 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 11)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_1 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_1 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 12)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_1 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_1 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 13)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_1 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_1 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 14)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_1 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_1 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 15)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_1 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_1 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (assignment_stmt Stmt_ConstDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " Exp26__5 ") , (expr Expr_Var ( (ident " result__5_1 ") )) )))
+  (stmt (assignment_stmt Stmt_VarDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " result__5_2 ") , (expr (bits '0000')) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 16)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_2 ") )) , (expr (bits '0001')) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 17)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_2 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_2 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 18)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_2 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_2 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 19)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_2 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_2 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 20)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_2 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_2 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 21)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_2 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_2 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 22)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_2 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_2 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 23)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_2 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_2 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (assignment_stmt Stmt_ConstDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " Exp37__5 ") , (expr Expr_Var ( (ident " result__5_2 ") )) )))
+  (stmt (assignment_stmt Stmt_VarDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " result__5_3 ") , (expr (bits '0000')) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 24)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_3 ") )) , (expr (bits '0001')) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 25)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_3 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_3 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 26)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_3 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_3 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 27)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_3 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_3 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 28)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_3 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_3 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 29)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_3 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_3 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 30)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_3 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_3 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 31)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_3 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_3 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (assignment_stmt Stmt_ConstDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " Exp48__5 ") , (expr Expr_Var ( (ident " result__5_3 ") )) )))
+  (stmt (assignment_stmt Stmt_VarDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " result__5_4 ") , (expr (bits '0000')) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 32)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_4 ") )) , (expr (bits '0001')) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 33)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_4 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_4 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 34)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_4 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_4 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 35)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_4 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_4 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 36)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_4 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_4 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 37)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_4 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_4 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 38)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_4 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_4 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 39)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_4 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_4 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (assignment_stmt Stmt_ConstDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " Exp59__5 ") , (expr Expr_Var ( (ident " result__5_4 ") )) )))
+  (stmt (assignment_stmt Stmt_VarDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " result__5_5 ") , (expr (bits '0000')) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 40)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_5 ") )) , (expr (bits '0001')) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 41)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 42)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 43)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 44)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 45)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 46)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 47)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_5 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_5 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (assignment_stmt Stmt_ConstDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " Exp70__5 ") , (expr Expr_Var ( (ident " result__5_5 ") )) )))
+  (stmt (assignment_stmt Stmt_VarDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " result__5_6 ") , (expr (bits '0000')) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 48)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_6 ") )) , (expr (bits '0001')) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 49)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_6 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_6 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 50)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_6 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_6 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 51)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_6 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_6 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 52)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_6 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_6 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 53)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_6 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_6 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 54)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_6 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_6 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 55)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_6 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_6 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (assignment_stmt Stmt_ConstDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " Exp81__5 ") , (expr Expr_Var ( (ident " result__5_6 ") )) )))
+  (stmt (assignment_stmt Stmt_VarDecl ( (type Type_Bits ( (expr (integer 4)) )) , (ident " result__5_7 ") , (expr (bits '0000')) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 56)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_7 ") )) , (expr (bits '0001')) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 57)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_7 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_7 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 58)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_7 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_7 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 59)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_7 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_7 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 60)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_7 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_7 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 61)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_7 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_7 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 62)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_7 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_7 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (conditional_stmt Stmt_If ( (expr Expr_TApply ( (ident " eq_bits.0 ") , [ (targs (expr (integer 1))) ] , [ (expr Expr_Slices ( (expr Expr_Array ( (expr Expr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , [ (slice Slice_LoWd ( (expr (integer 63)) , (expr (integer 1)) )) ] )) ; (expr (bits '1')) ] )) ,
+  (stmts [
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Var ( (ident " result__5_7 ") )) , (expr Expr_TApply ( (ident " add_bits.0 ") , [ (targs (expr (integer 4))) ] , [ (expr Expr_Var ( (ident " result__5_7 ") )) ; (expr (bits '0001')) ] )) ))) ]) , [ ] ,
+  (stmts [ ]) )))
+  (stmt (assignment_stmt Stmt_Assign ( (lexpr LExpr_Array ( (lexpr LExpr_Var ( (ident " _Z ") )) , (expr (integer 0)) )) , (expr Expr_TApply ( (ident " ZeroExtend.0 ") , [ (targs (expr (integer 64))) ; (targs (expr (integer 128))) ] , [ (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 8))) ; (targs (expr (integer 56))) ] , [ (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 4))) ; (targs (expr (integer 4))) ] , [ (expr (bits '0000')) ; (expr Expr_Var ( (ident " result__5_7 ") )) ] )) ; (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 8))) ; (targs (expr (integer 48))) ] , [ (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 4))) ; (targs (expr (integer 4))) ] , [ (expr (bits '0000')) ; (expr Expr_Var ( (ident " Exp81__5 ") )) ] )) ; (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 8))) ; (targs (expr (integer 40))) ] , [ (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 4))) ; (targs (expr (integer 4))) ] , [ (expr (bits '0000')) ; (expr Expr_Var ( (ident " Exp70__5 ") )) ] )) ; (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 8))) ; (targs (expr (integer 32))) ] , [ (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 4))) ; (targs (expr (integer 4))) ] , [ (expr (bits '0000')) ; (expr Expr_Var ( (ident " Exp59__5 ") )) ] )) ; (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 8))) ; (targs (expr (integer 24))) ] , [ (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 4))) ; (targs (expr (integer 4))) ] , [ (expr (bits '0000')) ; (expr Expr_Var ( (ident " Exp48__5 ") )) ] )) ; (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 8))) ; (targs (expr (integer 16))) ] , [ (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 4))) ; (targs (expr (integer 4))) ] , [ (expr (bits '0000')) ; (expr Expr_Var ( (ident " Exp37__5 ") )) ] )) ; (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 8))) ; (targs (expr (integer 8))) ] , [ (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 4))) ; (targs (expr (integer 4))) ] , [ (expr (bits '0000')) ; (expr Expr_Var ( (ident " Exp26__5 ") )) ] )) ; (expr Expr_TApply ( (ident " append_bits.0 ") , [ (targs (expr (integer 4))) ; (targs (expr (integer 4))) ] , [ (expr (bits '0000')) ; (expr Expr_Var ( (ident " Exp14__5 ") )) ] )) ] )) ] )) ] )) ] )) ] )) ] )) ] )) ; (expr (integer 128)) ] )) ))) <EOF>)
 
   $ cat antlr_err

--- a/tests/aslt/test_dis.t
+++ b/tests/aslt/test_dis.t
@@ -176,4 +176,425 @@ run asli with these commands
   Stmt_Assign(LExpr_Var("result__4"),Expr_TApply("append_bits.0",[8;56],[Expr_Slices(Expr_TApply("lsr_bits.0",[128;12],[Expr_Array(Expr_Var("_Z"),0);Expr_TApply("ZeroExtend.0",[11;12],[Expr_TApply("mul_bits.0",[11],[Expr_Var("Cse0__5");'00000001000']);12])]),[Slice_LoWd(0,8)]);Expr_Slices(Expr_Var("result__4"),[Slice_LoWd(0,56)])]))
   ],[],[])
   Stmt_Assign(LExpr_Array(LExpr_Var("_Z"),0),Expr_TApply("ZeroExtend.0",[64;128],[Expr_Var("result__4");128]))
+  "
+  0x0e205800
+  "
+  Decoding instruction A64 e205800
+  bits ( 4 ) result__5 = '0000' ;
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 0 +: 1 ],'1' ) then {
+  result__5 = '0001' ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 1 +: 1 ],'1' ) then {
+  result__5 = add_bits.0 {{ 4 }} ( result__5,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 2 +: 1 ],'1' ) then {
+  result__5 = add_bits.0 {{ 4 }} ( result__5,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 3 +: 1 ],'1' ) then {
+  result__5 = add_bits.0 {{ 4 }} ( result__5,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 4 +: 1 ],'1' ) then {
+  result__5 = add_bits.0 {{ 4 }} ( result__5,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 5 +: 1 ],'1' ) then {
+  result__5 = add_bits.0 {{ 4 }} ( result__5,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 6 +: 1 ],'1' ) then {
+  result__5 = add_bits.0 {{ 4 }} ( result__5,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 7 +: 1 ],'1' ) then {
+  result__5 = add_bits.0 {{ 4 }} ( result__5,'0001' ) ;
+  }
+  constant bits ( 4 ) Exp14__5 = result__5 ;
+  bits ( 4 ) result__5_1 = '0000' ;
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 8 +: 1 ],'1' ) then {
+  result__5_1 = '0001' ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 9 +: 1 ],'1' ) then {
+  result__5_1 = add_bits.0 {{ 4 }} ( result__5_1,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 10 +: 1 ],'1' ) then {
+  result__5_1 = add_bits.0 {{ 4 }} ( result__5_1,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 11 +: 1 ],'1' ) then {
+  result__5_1 = add_bits.0 {{ 4 }} ( result__5_1,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 12 +: 1 ],'1' ) then {
+  result__5_1 = add_bits.0 {{ 4 }} ( result__5_1,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 13 +: 1 ],'1' ) then {
+  result__5_1 = add_bits.0 {{ 4 }} ( result__5_1,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 14 +: 1 ],'1' ) then {
+  result__5_1 = add_bits.0 {{ 4 }} ( result__5_1,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 15 +: 1 ],'1' ) then {
+  result__5_1 = add_bits.0 {{ 4 }} ( result__5_1,'0001' ) ;
+  }
+  constant bits ( 4 ) Exp26__5 = result__5_1 ;
+  bits ( 4 ) result__5_2 = '0000' ;
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 16 +: 1 ],'1' ) then {
+  result__5_2 = '0001' ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 17 +: 1 ],'1' ) then {
+  result__5_2 = add_bits.0 {{ 4 }} ( result__5_2,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 18 +: 1 ],'1' ) then {
+  result__5_2 = add_bits.0 {{ 4 }} ( result__5_2,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 19 +: 1 ],'1' ) then {
+  result__5_2 = add_bits.0 {{ 4 }} ( result__5_2,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 20 +: 1 ],'1' ) then {
+  result__5_2 = add_bits.0 {{ 4 }} ( result__5_2,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 21 +: 1 ],'1' ) then {
+  result__5_2 = add_bits.0 {{ 4 }} ( result__5_2,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 22 +: 1 ],'1' ) then {
+  result__5_2 = add_bits.0 {{ 4 }} ( result__5_2,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 23 +: 1 ],'1' ) then {
+  result__5_2 = add_bits.0 {{ 4 }} ( result__5_2,'0001' ) ;
+  }
+  constant bits ( 4 ) Exp37__5 = result__5_2 ;
+  bits ( 4 ) result__5_3 = '0000' ;
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 24 +: 1 ],'1' ) then {
+  result__5_3 = '0001' ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 25 +: 1 ],'1' ) then {
+  result__5_3 = add_bits.0 {{ 4 }} ( result__5_3,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 26 +: 1 ],'1' ) then {
+  result__5_3 = add_bits.0 {{ 4 }} ( result__5_3,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 27 +: 1 ],'1' ) then {
+  result__5_3 = add_bits.0 {{ 4 }} ( result__5_3,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 28 +: 1 ],'1' ) then {
+  result__5_3 = add_bits.0 {{ 4 }} ( result__5_3,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 29 +: 1 ],'1' ) then {
+  result__5_3 = add_bits.0 {{ 4 }} ( result__5_3,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 30 +: 1 ],'1' ) then {
+  result__5_3 = add_bits.0 {{ 4 }} ( result__5_3,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 31 +: 1 ],'1' ) then {
+  result__5_3 = add_bits.0 {{ 4 }} ( result__5_3,'0001' ) ;
+  }
+  constant bits ( 4 ) Exp48__5 = result__5_3 ;
+  bits ( 4 ) result__5_4 = '0000' ;
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 32 +: 1 ],'1' ) then {
+  result__5_4 = '0001' ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 33 +: 1 ],'1' ) then {
+  result__5_4 = add_bits.0 {{ 4 }} ( result__5_4,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 34 +: 1 ],'1' ) then {
+  result__5_4 = add_bits.0 {{ 4 }} ( result__5_4,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 35 +: 1 ],'1' ) then {
+  result__5_4 = add_bits.0 {{ 4 }} ( result__5_4,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 36 +: 1 ],'1' ) then {
+  result__5_4 = add_bits.0 {{ 4 }} ( result__5_4,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 37 +: 1 ],'1' ) then {
+  result__5_4 = add_bits.0 {{ 4 }} ( result__5_4,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 38 +: 1 ],'1' ) then {
+  result__5_4 = add_bits.0 {{ 4 }} ( result__5_4,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 39 +: 1 ],'1' ) then {
+  result__5_4 = add_bits.0 {{ 4 }} ( result__5_4,'0001' ) ;
+  }
+  constant bits ( 4 ) Exp59__5 = result__5_4 ;
+  bits ( 4 ) result__5_5 = '0000' ;
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 40 +: 1 ],'1' ) then {
+  result__5_5 = '0001' ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 41 +: 1 ],'1' ) then {
+  result__5_5 = add_bits.0 {{ 4 }} ( result__5_5,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 42 +: 1 ],'1' ) then {
+  result__5_5 = add_bits.0 {{ 4 }} ( result__5_5,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 43 +: 1 ],'1' ) then {
+  result__5_5 = add_bits.0 {{ 4 }} ( result__5_5,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 44 +: 1 ],'1' ) then {
+  result__5_5 = add_bits.0 {{ 4 }} ( result__5_5,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 45 +: 1 ],'1' ) then {
+  result__5_5 = add_bits.0 {{ 4 }} ( result__5_5,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 46 +: 1 ],'1' ) then {
+  result__5_5 = add_bits.0 {{ 4 }} ( result__5_5,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 47 +: 1 ],'1' ) then {
+  result__5_5 = add_bits.0 {{ 4 }} ( result__5_5,'0001' ) ;
+  }
+  constant bits ( 4 ) Exp70__5 = result__5_5 ;
+  bits ( 4 ) result__5_6 = '0000' ;
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 48 +: 1 ],'1' ) then {
+  result__5_6 = '0001' ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 49 +: 1 ],'1' ) then {
+  result__5_6 = add_bits.0 {{ 4 }} ( result__5_6,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 50 +: 1 ],'1' ) then {
+  result__5_6 = add_bits.0 {{ 4 }} ( result__5_6,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 51 +: 1 ],'1' ) then {
+  result__5_6 = add_bits.0 {{ 4 }} ( result__5_6,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 52 +: 1 ],'1' ) then {
+  result__5_6 = add_bits.0 {{ 4 }} ( result__5_6,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 53 +: 1 ],'1' ) then {
+  result__5_6 = add_bits.0 {{ 4 }} ( result__5_6,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 54 +: 1 ],'1' ) then {
+  result__5_6 = add_bits.0 {{ 4 }} ( result__5_6,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 55 +: 1 ],'1' ) then {
+  result__5_6 = add_bits.0 {{ 4 }} ( result__5_6,'0001' ) ;
+  }
+  constant bits ( 4 ) Exp81__5 = result__5_6 ;
+  bits ( 4 ) result__5_7 = '0000' ;
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 56 +: 1 ],'1' ) then {
+  result__5_7 = '0001' ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 57 +: 1 ],'1' ) then {
+  result__5_7 = add_bits.0 {{ 4 }} ( result__5_7,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 58 +: 1 ],'1' ) then {
+  result__5_7 = add_bits.0 {{ 4 }} ( result__5_7,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 59 +: 1 ],'1' ) then {
+  result__5_7 = add_bits.0 {{ 4 }} ( result__5_7,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 60 +: 1 ],'1' ) then {
+  result__5_7 = add_bits.0 {{ 4 }} ( result__5_7,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 61 +: 1 ],'1' ) then {
+  result__5_7 = add_bits.0 {{ 4 }} ( result__5_7,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 62 +: 1 ],'1' ) then {
+  result__5_7 = add_bits.0 {{ 4 }} ( result__5_7,'0001' ) ;
+  }
+  if eq_bits.0 {{ 1 }} ( __array _Z [ 0 ] [ 63 +: 1 ],'1' ) then {
+  result__5_7 = add_bits.0 {{ 4 }} ( result__5_7,'0001' ) ;
+  }
+  __array _Z [ 0 ] = ZeroExtend.0 {{ 64,128 }} ( append_bits.0 {{ 8,56 }} ( append_bits.0 {{ 4,4 }} ( '0000',result__5_7 ),append_bits.0 {{ 8,48 }} ( append_bits.0 {{ 4,4 }} ( '0000',Exp81__5 ),append_bits.0 {{ 8,40 }} ( append_bits.0 {{ 4,4 }} ( '0000',Exp70__5 ),append_bits.0 {{ 8,32 }} ( append_bits.0 {{ 4,4 }} ( '0000',Exp59__5 ),append_bits.0 {{ 8,24 }} ( append_bits.0 {{ 4,4 }} ( '0000',Exp48__5 ),append_bits.0 {{ 8,16 }} ( append_bits.0 {{ 4,4 }} ( '0000',Exp37__5 ),append_bits.0 {{ 8,8 }} ( append_bits.0 {{ 4,4 }} ( '0000',Exp26__5 ),append_bits.0 {{ 4,4 }} ( '0000',Exp14__5 ) ) ) ) ) ) ) ),128 ) ;
+  ""
+  Stmt_VarDecl(Type_Bits(4),"result__5",'0000')
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(0,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5"),'0001')
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(1,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(2,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(3,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(4,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(5,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(6,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(7,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5");'0001']))
+  ],[],[])
+  Stmt_ConstDecl(Type_Bits(4),"Exp14__5",Expr_Var("result__5"))
+  Stmt_VarDecl(Type_Bits(4),"result__5_1",'0000')
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(8,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_1"),'0001')
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(9,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_1"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_1");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(10,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_1"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_1");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(11,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_1"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_1");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(12,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_1"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_1");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(13,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_1"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_1");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(14,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_1"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_1");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(15,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_1"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_1");'0001']))
+  ],[],[])
+  Stmt_ConstDecl(Type_Bits(4),"Exp26__5",Expr_Var("result__5_1"))
+  Stmt_VarDecl(Type_Bits(4),"result__5_2",'0000')
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(16,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_2"),'0001')
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(17,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_2"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_2");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(18,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_2"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_2");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(19,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_2"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_2");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(20,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_2"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_2");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(21,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_2"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_2");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(22,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_2"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_2");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(23,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_2"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_2");'0001']))
+  ],[],[])
+  Stmt_ConstDecl(Type_Bits(4),"Exp37__5",Expr_Var("result__5_2"))
+  Stmt_VarDecl(Type_Bits(4),"result__5_3",'0000')
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(24,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_3"),'0001')
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(25,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_3"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_3");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(26,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_3"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_3");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(27,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_3"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_3");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(28,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_3"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_3");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(29,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_3"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_3");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(30,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_3"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_3");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(31,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_3"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_3");'0001']))
+  ],[],[])
+  Stmt_ConstDecl(Type_Bits(4),"Exp48__5",Expr_Var("result__5_3"))
+  Stmt_VarDecl(Type_Bits(4),"result__5_4",'0000')
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(32,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_4"),'0001')
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(33,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_4"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_4");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(34,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_4"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_4");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(35,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_4"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_4");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(36,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_4"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_4");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(37,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_4"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_4");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(38,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_4"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_4");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(39,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_4"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_4");'0001']))
+  ],[],[])
+  Stmt_ConstDecl(Type_Bits(4),"Exp59__5",Expr_Var("result__5_4"))
+  Stmt_VarDecl(Type_Bits(4),"result__5_5",'0000')
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(40,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_5"),'0001')
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(41,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_5");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(42,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_5");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(43,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_5");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(44,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_5");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(45,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_5");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(46,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_5");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(47,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_5"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_5");'0001']))
+  ],[],[])
+  Stmt_ConstDecl(Type_Bits(4),"Exp70__5",Expr_Var("result__5_5"))
+  Stmt_VarDecl(Type_Bits(4),"result__5_6",'0000')
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(48,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_6"),'0001')
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(49,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_6"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_6");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(50,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_6"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_6");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(51,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_6"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_6");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(52,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_6"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_6");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(53,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_6"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_6");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(54,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_6"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_6");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(55,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_6"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_6");'0001']))
+  ],[],[])
+  Stmt_ConstDecl(Type_Bits(4),"Exp81__5",Expr_Var("result__5_6"))
+  Stmt_VarDecl(Type_Bits(4),"result__5_7",'0000')
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(56,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_7"),'0001')
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(57,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_7"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_7");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(58,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_7"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_7");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(59,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_7"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_7");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(60,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_7"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_7");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(61,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_7"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_7");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(62,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_7"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_7");'0001']))
+  ],[],[])
+  Stmt_If(Expr_TApply("eq_bits.0",[1],[Expr_Slices(Expr_Array(Expr_Var("_Z"),0),[Slice_LoWd(63,1)]);'1']),[
+  Stmt_Assign(LExpr_Var("result__5_7"),Expr_TApply("add_bits.0",[4],[Expr_Var("result__5_7");'0001']))
+  ],[],[])
+  Stmt_Assign(LExpr_Array(LExpr_Var("_Z"),0),Expr_TApply("ZeroExtend.0",[64;128],[Expr_TApply("append_bits.0",[8;56],[Expr_TApply("append_bits.0",[4;4],['0000';Expr_Var("result__5_7")]);Expr_TApply("append_bits.0",[8;48],[Expr_TApply("append_bits.0",[4;4],['0000';Expr_Var("Exp81__5")]);Expr_TApply("append_bits.0",[8;40],[Expr_TApply("append_bits.0",[4;4],['0000';Expr_Var("Exp70__5")]);Expr_TApply("append_bits.0",[8;32],[Expr_TApply("append_bits.0",[4;4],['0000';Expr_Var("Exp59__5")]);Expr_TApply("append_bits.0",[8;24],[Expr_TApply("append_bits.0",[4;4],['0000';Expr_Var("Exp48__5")]);Expr_TApply("append_bits.0",[8;16],[Expr_TApply("append_bits.0",[4;4],['0000';Expr_Var("Exp37__5")]);Expr_TApply("append_bits.0",[8;8],[Expr_TApply("append_bits.0",[4;4],['0000';Expr_Var("Exp26__5")]);Expr_TApply("append_bits.0",[4;4],['0000';Expr_Var("Exp14__5")])])])])])])])]);128]))
 


### PR DESCRIPTION
adds test for #43. depends on #67.