### PR TITLE
implement aslBackwardsVisitor

### DIFF
--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -226,7 +226,7 @@ let fv_stmts stmts =
 
 let fv_stmt stmt =
     let fvs = new freevarClass in
-    ignore (visit_stmt (fvs :> aslVisitor) stmt);
+    ignore (visit_stmt_single (fvs :> aslVisitor) stmt);
     fvs#result
 
 let fv_decl decl =
@@ -295,7 +295,7 @@ end
 
 let locals_of_stmts stmts =
     let lc = new localsClass in
-    ignore (Visitor.mapNoCopy (visit_stmt (lc :> aslVisitor)) stmts);
+    ignore @@ Asl_visitor.visit_stmts lc stmts;
     lc#locals
 
 let locals_of_decl decl =
@@ -423,7 +423,7 @@ let subst_type (s: expr Bindings.t) (x: ty): ty =
 
 let subst_stmt (s: expr Bindings.t) (x: stmt): stmt =
     let subst = new substClass s in
-    visit_stmt subst x
+    visit_stmt_single subst x
 
 
 (** More flexible substitution class - takes a function instead

--- a/libASL/asl_visitor.ml
+++ b/libASL/asl_visitor.ml
@@ -77,7 +77,7 @@ let args_of_encoding (Encoding_Block (_, _, fs, _, _, _, _, _)): (ty * ident) li
     List.map arg_of_ifield fs
 
 
-class aslTreeVisitor (vis: #aslVisitor) = object(self)
+class aslForwardsVisitor (vis: #aslVisitor) = object(self)
 
     method visit_exprs (xs: expr list): expr list =
         mapNoCopy (self#visit_expr) xs
@@ -716,61 +716,72 @@ class aslTreeVisitor (vis: #aslVisitor) = object(self)
         doVisit vis (vis#vdecl x) aux x
 end
 
-(* convenience methods to visit with the ordinary forwards aslTreeVisitor. *)
+(** visit statement lists in a backwards order.
+    i.e., enter_scope is called before the final statement in a block and
+    exit_scope is called after the initial statement. *)
+class aslBackwardsVisitor (vis: #aslVisitor) = object
+    inherit aslForwardsVisitor vis as forwards
 
-let visit_exprs (vis: #aslVisitor) : expr list -> expr list = (new aslTreeVisitor vis)#visit_exprs
+    method! visit_stmts (xs: stmt list): stmt list =
+        List.rev @@ forwards#visit_stmts (List.rev xs)
+end
 
-let visit_var (vis: #aslVisitor) : ident -> ident = (new aslTreeVisitor vis)#visit_var
 
-let visit_lvar (vis: #aslVisitor) : ident -> ident = (new aslTreeVisitor vis)#visit_lvar
+(* convenience methods to visit with the ordinary aslForwardsVisitor. *)
 
-let visit_e_elsif (vis: #aslVisitor) : e_elsif -> e_elsif = (new aslTreeVisitor vis)#visit_e_elsif
+let visit_exprs (vis: #aslVisitor) : expr list -> expr list = (new aslForwardsVisitor vis)#visit_exprs
 
-let visit_slice (vis: #aslVisitor) : slice -> slice = (new aslTreeVisitor vis)#visit_slice
+let visit_var (vis: #aslVisitor) : ident -> ident = (new aslForwardsVisitor vis)#visit_var
 
-let visit_patterns (vis: #aslVisitor) : pattern list -> pattern list = (new aslTreeVisitor vis)#visit_patterns
+let visit_lvar (vis: #aslVisitor) : ident -> ident = (new aslForwardsVisitor vis)#visit_lvar
 
-let visit_pattern (vis: #aslVisitor) : pattern -> pattern = (new aslTreeVisitor vis)#visit_pattern
+let visit_e_elsif (vis: #aslVisitor) : e_elsif -> e_elsif = (new aslForwardsVisitor vis)#visit_e_elsif
 
-let visit_expr (vis: #aslVisitor) : expr -> expr = (new aslTreeVisitor vis)#visit_expr
+let visit_slice (vis: #aslVisitor) : slice -> slice = (new aslForwardsVisitor vis)#visit_slice
 
-let visit_types (vis: #aslVisitor) : ty list -> ty list = (new aslTreeVisitor vis)#visit_types
+let visit_patterns (vis: #aslVisitor) : pattern list -> pattern list = (new aslForwardsVisitor vis)#visit_patterns
 
-let visit_type (vis: #aslVisitor) : ty -> ty = (new aslTreeVisitor vis)#visit_type
+let visit_pattern (vis: #aslVisitor) : pattern -> pattern = (new aslForwardsVisitor vis)#visit_pattern
 
-let visit_lexprs (vis: #aslVisitor) : lexpr list -> lexpr list = (new aslTreeVisitor vis)#visit_lexprs
+let visit_expr (vis: #aslVisitor) : expr -> expr = (new aslForwardsVisitor vis)#visit_expr
 
-let visit_lexpr (vis: #aslVisitor) : lexpr -> lexpr = (new aslTreeVisitor vis)#visit_lexpr
+let visit_types (vis: #aslVisitor) : ty list -> ty list = (new aslForwardsVisitor vis)#visit_types
 
-let visit_stmts (vis: #aslVisitor) : stmt list -> stmt list = (new aslTreeVisitor vis)#visit_stmts
+let visit_type (vis: #aslVisitor) : ty -> ty = (new aslForwardsVisitor vis)#visit_type
 
-let visit_stmt (vis: #aslVisitor) : stmt -> stmt = (new aslTreeVisitor vis)#visit_stmt
+let visit_lexprs (vis: #aslVisitor) : lexpr list -> lexpr list = (new aslForwardsVisitor vis)#visit_lexprs
 
-let visit_s_elsif (vis: #aslVisitor) : s_elsif -> s_elsif = (new aslTreeVisitor vis)#visit_s_elsif
+let visit_lexpr (vis: #aslVisitor) : lexpr -> lexpr = (new aslForwardsVisitor vis)#visit_lexpr
 
-let visit_alt (vis: #aslVisitor) : alt -> alt = (new aslTreeVisitor vis)#visit_alt
+let visit_stmts (vis: #aslVisitor) : stmt list -> stmt list = (new aslForwardsVisitor vis)#visit_stmts
 
-let visit_catcher (vis: #aslVisitor) : catcher -> catcher = (new aslTreeVisitor vis)#visit_catcher
+let visit_stmt (vis: #aslVisitor) : stmt -> stmt = (new aslForwardsVisitor vis)#visit_stmt
 
-let visit_mapfield (vis: #aslVisitor) : mapfield -> mapfield = (new aslTreeVisitor vis)#visit_mapfield
+let visit_s_elsif (vis: #aslVisitor) : s_elsif -> s_elsif = (new aslForwardsVisitor vis)#visit_s_elsif
 
-let visit_sformal (vis: #aslVisitor) : sformal -> sformal = (new aslTreeVisitor vis)#visit_sformal
+let visit_alt (vis: #aslVisitor) : alt -> alt = (new aslForwardsVisitor vis)#visit_alt
 
-let visit_dpattern (vis: #aslVisitor) : decode_pattern -> decode_pattern = (new aslTreeVisitor vis)#visit_dpattern
+let visit_catcher (vis: #aslVisitor) : catcher -> catcher = (new aslForwardsVisitor vis)#visit_catcher
 
-let visit_encoding (vis: #aslVisitor) : encoding -> encoding = (new aslTreeVisitor vis)#visit_encoding
+let visit_mapfield (vis: #aslVisitor) : mapfield -> mapfield = (new aslForwardsVisitor vis)#visit_mapfield
 
-let visit_decode_case (vis: #aslVisitor) : decode_case -> decode_case = (new aslTreeVisitor vis)#visit_decode_case
+let visit_sformal (vis: #aslVisitor) : sformal -> sformal = (new aslForwardsVisitor vis)#visit_sformal
 
-let visit_decode_alt (vis: #aslVisitor) : decode_alt -> decode_alt = (new aslTreeVisitor vis)#visit_decode_alt
+let visit_dpattern (vis: #aslVisitor) : decode_pattern -> decode_pattern = (new aslForwardsVisitor vis)#visit_dpattern
 
-let visit_decode_body (vis: #aslVisitor) : decode_body -> decode_body = (new aslTreeVisitor vis)#visit_decode_body
+let visit_encoding (vis: #aslVisitor) : encoding -> encoding = (new aslForwardsVisitor vis)#visit_encoding
 
-let visit_arg (vis: #aslVisitor) : (ty * ident) -> (ty * ident) = (new aslTreeVisitor vis)#visit_arg
+let visit_decode_case (vis: #aslVisitor) : decode_case -> decode_case = (new aslForwardsVisitor vis)#visit_decode_case
 
-let visit_args (vis: #aslVisitor) : (ty * ident) list -> (ty * ident) list = (new aslTreeVisitor vis)#visit_args
+let visit_decode_alt (vis: #aslVisitor) : decode_alt -> decode_alt = (new aslForwardsVisitor vis)#visit_decode_alt
 
-let visit_decl (vis: #aslVisitor) : declaration -> declaration = (new aslTreeVisitor vis)#visit_decl
+let visit_decode_body (vis: #aslVisitor) : decode_body -> decode_body = (new aslForwardsVisitor vis)#visit_decode_body
+
+let visit_arg (vis: #aslVisitor) : (ty * ident) -> (ty * ident) = (new aslForwardsVisitor vis)#visit_arg
+
+let visit_args (vis: #aslVisitor) : (ty * ident) list -> (ty * ident) list = (new aslForwardsVisitor vis)#visit_args
+
+let visit_decl (vis: #aslVisitor) : declaration -> declaration = (new aslForwardsVisitor vis)#visit_decl
 
 
 (****************************************************************)

--- a/libASL/asl_visitor.ml
+++ b/libASL/asl_visitor.ml
@@ -65,55 +65,69 @@ end
     different.
  *)
 
-let rec visit_exprs (vis: #aslVisitor) (xs: expr list): expr list =
-        mapNoCopy (visit_expr vis) xs
+let arg_of_sformal (sf: sformal): (ty * ident) =
+    match sf with
+    | Formal_In (ty, id)
+    | Formal_InOut (ty, id) -> (ty, id)
 
-    and visit_var (vis: #aslVisitor) (x: ident): ident =
+let arg_of_ifield (IField_Field (id, _, wd)): (ty * ident) =
+    (Type_Bits (Expr_LitInt (string_of_int wd)), id)
+
+let args_of_encoding (Encoding_Block (_, _, fs, _, _, _, _, _)): (ty * ident) list =
+    List.map arg_of_ifield fs
+
+
+class aslTreeVisitor (vis: #aslVisitor) = object(self)
+
+    method visit_exprs (xs: expr list): expr list =
+        mapNoCopy (self#visit_expr) xs
+
+    method visit_var (x: ident): ident =
         let aux (_: #aslVisitor) (x: ident): ident =
             x
         in
         doVisit vis (vis#vvar x) aux x
 
-    and visit_lvar (vis: #aslVisitor) (x: ident): ident =
+    method visit_lvar (x: ident): ident =
         let aux (_: #aslVisitor) (x: ident): ident =
             x
         in
         doVisit vis (vis#vlvar x) aux x
 
-    and visit_e_elsif (vis: #aslVisitor) (x: e_elsif): e_elsif =
-        let aux (vis: #aslVisitor) (x: e_elsif): e_elsif =
+    method visit_e_elsif (x: e_elsif): e_elsif =
+        let aux (_: #aslVisitor) (x: e_elsif): e_elsif =
             (match x with
             | E_Elsif_Cond(c, e) ->
-                    let c' = visit_expr vis c in
-                    let e' = visit_expr vis e in
+                    let c' = self#visit_expr c in
+                    let e' = self#visit_expr e in
                     if c == c' && e == e' then x else E_Elsif_Cond(c', e')
             )
         in
         doVisit vis (vis#ve_elsif x) aux x
 
-    and visit_slice (vis: #aslVisitor) (x: slice): slice =
-        let aux (vis: #aslVisitor) (x: slice): slice =
+    method visit_slice (x: slice): slice =
+        let aux (_: #aslVisitor) (x: slice): slice =
             (match x with
             | Slice_Single(e) ->
-                    let e' = visit_expr vis e in
+                    let e' = self#visit_expr e in
                     if e == e' then x else Slice_Single e'
             | Slice_HiLo(hi, lo) ->
-                    let hi' = visit_expr vis hi in
-                    let lo' = visit_expr vis lo in
+                    let hi' = self#visit_expr hi in
+                    let lo' = self#visit_expr lo in
                     if hi == hi' && lo == lo' then x else Slice_HiLo(hi', lo')
             | Slice_LoWd(lo, wd) ->
-                    let lo' = visit_expr vis lo in
-                    let wd' = visit_expr vis wd in
+                    let lo' = self#visit_expr lo in
+                    let wd' = self#visit_expr wd in
                     if lo == lo' && wd == wd' then x else Slice_LoWd(lo', wd')
             )
         in
         doVisit vis (vis#vslice x) aux x
 
-    and visit_patterns (vis: #aslVisitor) (xs: pattern list): pattern list =
-        mapNoCopy (visit_pattern vis) xs
+    method visit_patterns (xs: pattern list): pattern list =
+        mapNoCopy (self#visit_pattern) xs
 
-    and visit_pattern (vis: #aslVisitor) (x: pattern): pattern =
-        let aux (vis: #aslVisitor) (x: pattern): pattern =
+    method visit_pattern (x: pattern): pattern =
+        let aux (_: #aslVisitor) (x: pattern): pattern =
             ( match x with
             | Pat_LitInt(_)  -> x
             | Pat_LitHex(_)  -> x
@@ -122,75 +136,75 @@ let rec visit_exprs (vis: #aslVisitor) (xs: expr list): expr list =
             | Pat_Const(_)   -> x
             | Pat_Wildcard   -> x
             | Pat_Tuple(ps)  ->
-                    let ps' = visit_patterns vis ps in
+                    let ps' = self#visit_patterns ps in
                     if ps == ps' then x else Pat_Tuple ps'
             | Pat_Set(ps) ->
-                    let ps' = visit_patterns vis ps in
+                    let ps' = self#visit_patterns ps in
                     if ps == ps' then x else Pat_Set ps'
             | Pat_Single(e) ->
-                let e' = visit_expr vis e in
+                let e' = self#visit_expr e in
                 if e == e' then x else Pat_Single(e')
             | Pat_Range(lo, hi) ->
-                let lo' = visit_expr vis lo in
-                let hi' = visit_expr vis hi in
+                let lo' = self#visit_expr lo in
+                let hi' = self#visit_expr hi in
                 if lo == lo' && hi == hi' then x else Pat_Range(lo', hi')
             )
         in
         doVisit vis (vis#vpattern x) aux x
 
-    and visit_expr (vis: #aslVisitor) (x: expr): expr =
-        let aux (vis: #aslVisitor) (x: expr): expr =
+    method visit_expr (x: expr): expr =
+        let aux (_: #aslVisitor) (x: expr): expr =
             (match x with
             | Expr_If(ty, c, t, els, e) ->
-                    let ty   = visit_type vis ty in
-                    let c'   = visit_expr vis c in
-                    let t'   = visit_expr vis t in
-                    let els' = mapNoCopy (visit_e_elsif vis) els in
-                    let e'   = visit_expr vis e in
+                    let ty   = self#visit_type ty in
+                    let c'   = self#visit_expr c in
+                    let t'   = self#visit_expr t in
+                    let els' = mapNoCopy (self#visit_e_elsif) els in
+                    let e'   = self#visit_expr e in
                     if c == c' && t == t' && els == els' && e == e' then x else Expr_If(ty, c', t', els', e')
             | Expr_Binop(a, op, b) ->
-                    let a' = visit_expr vis a in
-                    let b' = visit_expr vis b in
+                    let a' = self#visit_expr a in
+                    let b' = self#visit_expr b in
                     if a == a' && b == b' then x else Expr_Binop(a', op, b')
             | Expr_Field(e, f) ->
-                    let e' = visit_expr vis e in
+                    let e' = self#visit_expr e in
                     if e == e' then x else Expr_Field(e', f)
             | Expr_Fields(e, fs) ->
-                    let e' = visit_expr vis e in
+                    let e' = self#visit_expr e in
                     if e == e' then x else Expr_Fields(e', fs)
             | Expr_Slices(e, ss) ->
-                    let e'  = visit_expr vis e in
-                    let ss' = mapNoCopy (visit_slice vis) ss in
+                    let e'  = self#visit_expr e in
+                    let ss' = mapNoCopy (self#visit_slice) ss in
                     if e == e' && ss == ss' then x else Expr_Slices(e', ss')
             | Expr_In(e, p) ->
-                    let e' = visit_expr vis e in
-                    let p' = visit_pattern vis p in
+                    let e' = self#visit_expr e in
+                    let p' = self#visit_pattern p in
                     if e == e' && p == p' then x else Expr_In(e', p')
             | Expr_Var(v) ->
-                    let v' = visit_var vis v in
+                    let v' = self#visit_var v in
                     if v == v' then x else Expr_Var(v')
             | Expr_Parens(e) ->
-                    let e' = visit_expr vis e in
+                    let e' = self#visit_expr e in
                     if e == e' then x else Expr_Parens e'
             | Expr_TApply(f, tes, es) ->
-                    let tes' = visit_exprs vis tes in
-                    let es'  = visit_exprs vis es in
+                    let tes' = self#visit_exprs tes in
+                    let es'  = self#visit_exprs es in
                     if tes == tes' && es == es' then x else Expr_TApply(f, tes', es')
             | Expr_Tuple(es) ->
-                    let es'  = visit_exprs vis es in
+                    let es'  = self#visit_exprs es in
                     if es == es' then x else Expr_Tuple es'
             | Expr_Unop(op, e) ->
-                    let e' = visit_expr vis e in
+                    let e' = self#visit_expr e in
                     if e == e' then x else Expr_Unop(op, e')
             | Expr_Unknown(t) ->
-                    let t' = visit_type vis t in
+                    let t' = self#visit_type t in
                     if t == t' then x else Expr_Unknown t'
             | Expr_ImpDef(t, os) ->
-                    let t' = visit_type vis t in
+                    let t' = self#visit_type t in
                     if t == t' then x else Expr_ImpDef(t', os)
             | Expr_Array(a, e) ->
-                    let a' = visit_expr vis a in
-                    let e' = visit_expr vis e in
+                    let a' = self#visit_expr a in
+                    let e' = self#visit_expr e in
                     if a == a' && e == e' then x else Expr_Array(a', e')
             | Expr_LitInt    _  -> x
             | Expr_LitHex    _  -> x
@@ -203,141 +217,142 @@ let rec visit_exprs (vis: #aslVisitor) (xs: expr list): expr list =
         doVisit vis (vis#vexpr x) aux x
 
 
-    and visit_types (vis: #aslVisitor) (xs: ty list): ty list =
-        mapNoCopy (visit_type vis) xs
+    method visit_types (xs: ty list): ty list =
+        mapNoCopy (self#visit_type) xs
 
-    and visit_type (vis: #aslVisitor) (x: ty): ty =
-        let aux (vis: #aslVisitor) (x: ty): ty =
+    method visit_type (x: ty): ty =
+        let aux (_: #aslVisitor) (x: ty): ty =
             ( match x with
             | Type_Constructor(_) -> x
             | Type_Bits(n) ->
-                    let n' = visit_expr vis n in
+                    let n' = self#visit_expr n in
                     if n == n' then x else Type_Bits(n')
             | Type_App(tc, es) ->
-                    let es' = visit_exprs vis es in
+                    let es' = self#visit_exprs es in
                     if es == es' then x else Type_App(tc, es')
             | Type_OfExpr(e) ->
-                    let e' = visit_expr vis e in
+                    let e' = self#visit_expr e in
                     if e == e' then x else Type_OfExpr(e')
             | Type_Register(wd, fs) ->
                     let fs' = mapNoCopy (fun ((ss, f) as r) ->
-                        let ss' = mapNoCopy (visit_slice vis) ss in
+                        let ss' = mapNoCopy (self#visit_slice) ss in
                         if ss == ss' then r else (ss', f)
                     ) fs in
                     if fs == fs' then x else Type_Register(wd, fs')
             | Type_Array(Index_Enum(tc), ety) ->
-                    let ety' = visit_type vis ety in
+                    let ety' = self#visit_type ety in
                     if ety == ety' then x else Type_Array(Index_Enum(tc), ety')
             | Type_Array(Index_Range(lo, hi), ety) ->
-                    let lo' = visit_expr vis lo in
-                    let hi' = visit_expr vis hi in
-                    let ety' = visit_type vis ety in
+                    let lo' = self#visit_expr lo in
+                    let hi' = self#visit_expr hi in
+                    let ety' = self#visit_type ety in
                     if lo == lo' && hi == hi' && ety == ety' then x else Type_Array(Index_Range(lo',hi'),ety')
             | Type_Tuple(tys) ->
-                    let tys' = visit_types vis tys in
+                    let tys' = self#visit_types tys in
                     if tys == tys' then x else Type_Tuple(tys')
             )
         in
         doVisit vis (vis#vtype x) aux x
 
-let rec visit_lexprs (vis: #aslVisitor) (xs: lexpr list): lexpr list =
-        mapNoCopy (visit_lexpr vis) xs
+    method visit_lexprs (xs: lexpr list): lexpr list =
+        mapNoCopy (self#visit_lexpr) xs
 
-    and visit_lexpr (vis: #aslVisitor) (x: lexpr): lexpr =
-        let aux (vis: #aslVisitor) (x: lexpr): lexpr =
+    method visit_lexpr (x: lexpr): lexpr =
+        let aux (_: #aslVisitor) (x: lexpr): lexpr =
             ( match x with
             | LExpr_Wildcard   -> x
             | LExpr_Var(v) ->
-                    let v' = visit_lvar vis v in
+                    let v' = self#visit_lvar v in
                     if v == v' then x else LExpr_Var(v')
             | LExpr_Field(e, f) ->
-                    let e' = visit_lexpr vis e in
+                    let e' = self#visit_lexpr e in
                     if e == e' then x else LExpr_Field(e', f)
             | LExpr_Fields(e, fs) ->
-                    let e' = visit_lexpr vis e in
+                    let e' = self#visit_lexpr e in
                     if e == e' then x else LExpr_Fields(e', fs)
             | LExpr_Slices(e, ss) ->
-                    let e'  = visit_lexpr vis e in
-                    let ss' = mapNoCopy (visit_slice vis) ss in
+                    let e'  = self#visit_lexpr e in
+                    let ss' = mapNoCopy (self#visit_slice) ss in
                     if e == e' && ss == ss' then x else LExpr_Slices(e', ss')
             | LExpr_BitTuple(es)  ->
-                    let es' = mapNoCopy (visit_lexpr vis) es in
+                    let es' = mapNoCopy (self#visit_lexpr) es in
                     if es == es' then x else LExpr_BitTuple es'
             | LExpr_Tuple(es)  ->
-                    let es' = mapNoCopy (visit_lexpr vis) es in
+                    let es' = mapNoCopy (self#visit_lexpr) es in
                     if es == es' then x else LExpr_Tuple es'
             | LExpr_Array(a, e) ->
-                    let a' = visit_lexpr vis a in
-                    let e' = visit_expr vis e in
+                    let a' = self#visit_lexpr a in
+                    let e' = self#visit_expr e in
                     if a == a' && e == e' then x else LExpr_Array(a', e')
             | LExpr_Write(f, tes, es) ->
-                    let f'   = visit_var vis f in
-                    let tes' = visit_exprs vis tes in
-                    let es'  = visit_exprs vis es in
+                    let f'   = self#visit_var f in
+                    let tes' = self#visit_exprs tes in
+                    let es'  = self#visit_exprs es in
                     if f == f' && tes == tes' && es == es' then x else LExpr_Write(f, tes', es')
             | LExpr_ReadWrite(f, g, tes, es) ->
-                    let f'   = visit_var vis f in
-                    let g'   = visit_var vis g in
-                    let tes' = visit_exprs vis tes in
-                    let es'  = visit_exprs vis es in
+                    let f'   = self#visit_var f in
+                    let g'   = self#visit_var g in
+                    let tes' = self#visit_exprs tes in
+                    let es'  = self#visit_exprs es in
                     if f == f' && g == g' && tes == tes' && es == es' then x else LExpr_ReadWrite(f, g, tes', es')
             )
         in
         doVisit vis (vis#vlexpr x) aux x
 
-let with_locals (ls: ((ty * ident) list)) (vis: #aslVisitor) (f: #aslVisitor -> 'a): 'a =
-    vis#enter_scope ls;
-    let result = f vis in
-    vis#leave_scope ();
-    result
 
-(* todo: should probably make this more like cil visitor and allow
- * visit_stmt to generate a list of statements and provide a mechanism to emit
- * statements to be inserted before/after the statement being transformed
- *)
-let rec visit_stmts (vis: #aslVisitor) (xs: stmt list): stmt list =
+    (* todo: should probably make this more like cil visitor and allow
+     * visit_stmt to generate a list of statements and provide a mechanism to emit
+     * statements to be inserted before/after the statement being transformed
+     *)
+    method visit_stmts (xs: stmt list): stmt list =
         vis#enter_scope [];
-        let stmts' = mapNoCopy (visit_stmt vis) xs in
+        let stmts' = mapNoCopy (self#visit_stmt) xs in
         vis#leave_scope ();
         stmts'
 
-    and visit_stmt (vis: #aslVisitor) (x: stmt): stmt =
-        let aux (vis: #aslVisitor) (x: stmt): stmt =
+    method with_locals (ls: ((ty * ident) list)) (f: 'a -> 'b) (x: 'a): 'b =
+        vis#enter_scope ls;
+        let result = f x in
+        vis#leave_scope ();
+        result
+
+    method visit_stmt (x: stmt): stmt =
+        let aux (_: #aslVisitor) (x: stmt): stmt =
             (match x with
             | Stmt_VarDeclsNoInit (ty, vs, loc) ->
-                    let ty' = visit_type vis ty in
-                    let vs' = mapNoCopy (visit_lvar vis) vs in
+                    let ty' = self#visit_type ty in
+                    let vs' = mapNoCopy (self#visit_lvar) vs in
                     if ty == ty' && vs == vs' then x else Stmt_VarDeclsNoInit (ty', vs', loc)
             | Stmt_VarDecl (ty, v, i, loc) ->
-                    let ty' = visit_type vis ty in
-                    let v' = visit_lvar vis v in
-                    let i' = visit_expr vis i in
+                    let ty' = self#visit_type ty in
+                    let v' = self#visit_lvar v in
+                    let i' = self#visit_expr i in
                     if ty == ty' && v == v' && i == i'  then x else Stmt_VarDecl (ty', v', i', loc)
             | Stmt_ConstDecl (ty, v, i, loc) ->
-                    let ty' = visit_type vis ty in
-                    let v' = visit_lvar vis v in
-                    let i' = visit_expr vis i in
+                    let ty' = self#visit_type ty in
+                    let v' = self#visit_lvar v in
+                    let i' = self#visit_expr i in
                     if ty == ty' && v == v' && i == i' then x else Stmt_ConstDecl (ty', v', i', loc)
             | Stmt_Assign (l, r, loc) ->
-                    let l' = visit_lexpr vis l in
-                    let r' = visit_expr vis r in
+                    let l' = self#visit_lexpr l in
+                    let r' = self#visit_expr r in
                     if l == l' && r == r' then x else Stmt_Assign (l', r', loc)
             | Stmt_TCall (f, tes, args, loc) ->
-                    let f'    = visit_var vis f in
-                    let tes'  = visit_exprs vis tes in
-                    let args' = visit_exprs vis args in
+                    let f'    = self#visit_var f in
+                    let tes'  = self#visit_exprs tes in
+                    let args' = self#visit_exprs args in
                     if f == f' && tes == tes' && args == args' then x else Stmt_TCall (f', tes', args', loc)
             | Stmt_FunReturn (e, loc) ->
-                    let e' = visit_expr vis e in
+                    let e' = self#visit_expr e in
                     if e == e' then x else Stmt_FunReturn (e', loc)
             | Stmt_ProcReturn (_) -> x
             | Stmt_Assert (e, loc) ->
-                    let e' = visit_expr vis e in
+                    let e' = self#visit_expr e in
                     if e == e' then x else Stmt_Assert (e', loc)
             | Stmt_Unpred (_) -> x
             | Stmt_ConstrainedUnpred(_) -> x
             | Stmt_ImpDef (v, loc) ->
-                    let v' = visit_var vis v in
+                    let v' = self#visit_var v in
                     if v == v' then x else Stmt_ImpDef (v', loc)
             | Stmt_Undefined (_) -> x
             | Stmt_ExceptionTaken (_) -> x
@@ -345,371 +360,361 @@ let rec visit_stmts (vis: #aslVisitor) (xs: stmt list): stmt list =
             | Stmt_Dep_ImpDef (_, _) -> x
             | Stmt_Dep_Undefined (_) -> x
             | Stmt_See (e, loc) ->
-                    let e' = visit_expr vis e in
+                    let e' = self#visit_expr e in
                     if e == e' then x else Stmt_See (e', loc)
             | Stmt_Throw (v, loc) ->
-                    let v' = visit_var vis v in
+                    let v' = self#visit_var v in
                     if v == v' then x else Stmt_Throw (v', loc)
             | Stmt_DecodeExecute (i, e, loc) ->
-                    let e' = visit_expr vis e in
+                    let e' = self#visit_expr e in
                     if e == e' then x else Stmt_DecodeExecute (i, e', loc)
             | Stmt_If (c, t, els, e, loc) ->
-                    let c'   = visit_expr vis c in
-                    let t'   = visit_stmts vis t in
-                    let els' = mapNoCopy (visit_s_elsif vis) els in
-                    let e'   = visit_stmts vis e in
+                    let c'   = self#visit_expr c in
+                    let t'   = self#visit_stmts t in
+                    let els' = mapNoCopy (self#visit_s_elsif) els in
+                    let e'   = self#visit_stmts e in
                     if c == c' && t == t' && els == els' && e == e' then x else Stmt_If (c', t', els', e', loc)
             | Stmt_Case (e, alts, ob, loc) ->
-                    let e'    = visit_expr vis e in
-                    let alts' = mapNoCopy (visit_alt vis) alts in
-                    let ob'   = mapOptionNoCopy (visit_stmts vis) ob in
+                    let e'    = self#visit_expr e in
+                    let alts' = mapNoCopy (self#visit_alt) alts in
+                    let ob'   = mapOptionNoCopy (self#visit_stmts) ob in
                     if e == e' && alts == alts' && ob == ob' then x else Stmt_Case (e', alts', ob', loc)
             | Stmt_For (v, f, dir, t, b, loc) ->
-                    let v' = visit_lvar vis v in
-                    let f' = visit_expr vis f in
-                    let t' = visit_expr vis t in
+                    let v' = self#visit_lvar v in
+                    let f' = self#visit_expr f in
+                    let t' = self#visit_expr t in
                     let ty_v' = (Type_Constructor(Ident "integer"), v') in
-                    let b' = with_locals [ty_v'] vis visit_stmts b in
+                    let b' = self#with_locals [ty_v'] self#visit_stmts b in
                     if v == v' && f == f' && t == t' && b == b' then x else Stmt_For (v', f', dir, t', b', loc)
             | Stmt_While (c, b, loc) ->
-                    let c' = visit_expr vis c in
-                    let b' = visit_stmts vis b in
+                    let c' = self#visit_expr c in
+                    let b' = self#visit_stmts b in
                     if c == c' && b == b' then x else Stmt_While (c', b', loc)
             | Stmt_Repeat (b, c, loc) ->
-                    let b' = visit_stmts vis b in
-                    let c' = visit_expr vis c in
+                    let b' = self#visit_stmts b in
+                    let c' = self#visit_expr c in
                     if b == b' && c == c' then x else Stmt_Repeat (b', c', loc)
             | Stmt_Try (b, v, cs, ob, loc) ->
-                    let b'  = visit_stmts vis b in
-                    let v'  = visit_lvar vis v in
+                    let b'  = self#visit_stmts b in
+                    let v'  = self#visit_lvar v in
                     let ty_v' = (Type_Constructor(Ident "__Exception"), v') in
-                    let cs' = mapNoCopy (with_locals [ty_v'] vis visit_catcher) cs in
-                    let ob' = mapOptionNoCopy (with_locals [ty_v'] vis visit_stmts) ob in
+                    let cs' = mapNoCopy (self#with_locals [ty_v'] self#visit_catcher) cs in
+                    let ob' = mapOptionNoCopy (self#with_locals [ty_v'] self#visit_stmts) ob in
                     if b == b' && v == v' && cs == cs' && ob == ob' then x else Stmt_Try (b', v', cs', ob', loc)
 
             )
         in
         doVisit vis (vis#vstmt x) aux x
 
-    and visit_s_elsif (vis: #aslVisitor) (x: s_elsif): s_elsif =
-        let aux (vis: #aslVisitor) (x: s_elsif): s_elsif =
+    method visit_s_elsif (x: s_elsif): s_elsif =
+        let aux (_: #aslVisitor) (x: s_elsif): s_elsif =
             (match x with
             | S_Elsif_Cond(c, b) ->
-                    let c' = visit_expr vis c in
-                    let b' = visit_stmts vis b in
+                    let c' = self#visit_expr c in
+                    let b' = self#visit_stmts b in
                     if c == c' && b == b' then x else S_Elsif_Cond(c', b')
             )
         in
         doVisit vis (vis#vs_elsif x) aux x
 
-    and visit_alt (vis: #aslVisitor) (x: alt): alt =
-        let aux (vis: #aslVisitor) (x: alt): alt =
+    method visit_alt (x: alt): alt =
+        let aux (_: #aslVisitor) (x: alt): alt =
             (match x with
             | Alt_Alt(ps, oc, b) ->
-                    let ps' = visit_patterns vis ps in
-                    let oc' = mapOptionNoCopy (visit_expr vis) oc in
-                    let b' = visit_stmts vis b in
+                    let ps' = self#visit_patterns ps in
+                    let oc' = mapOptionNoCopy (self#visit_expr) oc in
+                    let b' = self#visit_stmts b in
                     if ps == ps' && oc == oc' && b == b' then x else Alt_Alt(ps', oc', b')
             )
         in
         doVisit vis (vis#valt x) aux x
 
-    and visit_catcher (vis: #aslVisitor) (x: catcher): catcher =
-        let aux (vis: #aslVisitor) (x: catcher): catcher =
+    method visit_catcher (x: catcher): catcher =
+        let aux (_: #aslVisitor) (x: catcher): catcher =
             (match x with
             | Catcher_Guarded(c, b) ->
-                    let c' = visit_expr vis c in
-                    let b' = visit_stmts vis b in
+                    let c' = self#visit_expr c in
+                    let b' = self#visit_stmts b in
                     if c == c' && b == b' then x else Catcher_Guarded(c', b')
             )
         in
         doVisit vis (vis#vcatcher x) aux x
 
 
-let visit_mapfield (vis: #aslVisitor) (x: mapfield): mapfield =
-        let aux (vis: #aslVisitor) (x: mapfield): mapfield =
+    method visit_mapfield (x: mapfield): mapfield =
+        let aux (_: #aslVisitor) (x: mapfield): mapfield =
             (match x with
             | MapField_Field (v, p) ->
-                    let v' = visit_var vis v in
-                    let p' = visit_pattern vis p in
+                    let v' = self#visit_var v in
+                    let p' = self#visit_pattern p in
                     if v == v' && p == p' then x else MapField_Field (v', p')
             )
         in
         doVisit vis (vis#vmapfield x) aux x
 
-let visit_sformal (vis: #aslVisitor) (x: sformal): sformal =
-        let aux (vis: #aslVisitor) (x: sformal): sformal =
+    method visit_sformal (x: sformal): sformal =
+        let aux (_: #aslVisitor) (x: sformal): sformal =
             (match x with
             | Formal_In (ty, v) ->
-                    let ty' = visit_type vis ty in
-                    let v' = visit_lvar vis v in
+                    let ty' = self#visit_type ty in
+                    let v' = self#visit_lvar v in
                     if ty == ty' && v == v' then x else Formal_In (ty', v')
             | Formal_InOut(ty, v) ->
-                    let ty' = visit_type vis ty in
-                    let v' = visit_lvar vis v in
+                    let ty' = self#visit_type ty in
+                    let v' = self#visit_lvar v in
                     if ty == ty' && v == v' then x else Formal_InOut (ty', v')
             )
         in
         doVisit vis (vis#vsformal x) aux x
 
-let rec visit_dpattern (vis: #aslVisitor) (x: decode_pattern): decode_pattern =
-        let aux (vis: #aslVisitor) (x: decode_pattern): decode_pattern =
+    method visit_dpattern (x: decode_pattern): decode_pattern =
+        let aux (_: #aslVisitor) (x: decode_pattern): decode_pattern =
             (match x with
             | DecoderPattern_Bits _ -> x
             | DecoderPattern_Mask _ -> x
             | DecoderPattern_Wildcard _ -> x
             | DecoderPattern_Not p ->
-                    let p' = visit_dpattern vis p in
+                    let p' = self#visit_dpattern p in
                     if p == p' then x else DecoderPattern_Not p'
             )
         in
         doVisit vis (vis#vdpattern x) aux x
 
-let visit_encoding (vis: #aslVisitor) (x: encoding): encoding =
-        let aux (vis: #aslVisitor) (x: encoding): encoding =
+    method visit_encoding (x: encoding): encoding =
+        let aux (_: #aslVisitor) (x: encoding): encoding =
             (match x with
             | Encoding_Block (nm, iset, fs, op, e, ups, b, loc) ->
-                    let e' = visit_expr vis e in
-                    let b' = visit_stmts vis b in
+                    let e' = self#visit_expr e in
+                    let b' = self#visit_stmts b in
                     if e == e' && b == b' then x else Encoding_Block (nm, iset, fs, op, e, ups, b', loc)
             )
         in
         doVisit vis (vis#vencoding x) aux x
 
-let rec visit_decode_case (vis: #aslVisitor) (x: decode_case): decode_case =
-        let aux (vis: #aslVisitor) (x: decode_case): decode_case =
+    method visit_decode_case (x: decode_case): decode_case =
+        let aux (_: #aslVisitor) (x: decode_case): decode_case =
             (match x with
             | DecoderCase_Case (ss, alts, loc) ->
-                    let alts' = mapNoCopy (visit_decode_alt vis) alts in
+                    let alts' = mapNoCopy (self#visit_decode_alt) alts in
                     if alts == alts' then x else DecoderCase_Case (ss, alts', loc)
             )
         in
         doVisit vis (vis#vdcase x) aux x
 
-    and visit_decode_alt (vis: #aslVisitor) (x: decode_alt): decode_alt =
-        let aux (vis: #aslVisitor) (x: decode_alt): decode_alt =
+    method visit_decode_alt (x: decode_alt): decode_alt =
+        let aux (_: #aslVisitor) (x: decode_alt): decode_alt =
             (match x with
             | DecoderAlt_Alt (ps, b) ->
-                    let ps' = mapNoCopy (visit_dpattern vis) ps in
-                    let b'  = visit_decode_body vis b in
+                    let ps' = mapNoCopy (self#visit_dpattern) ps in
+                    let b'  = self#visit_decode_body b in
                     if ps == ps' && b == b' then x else
                     DecoderAlt_Alt (ps', b')
             )
         in
         doVisit vis (vis#vdalt x) aux x
 
-    and visit_decode_body (vis: #aslVisitor) (x: decode_body): decode_body =
-        let aux (vis: #aslVisitor) (x: decode_body): decode_body =
+    method visit_decode_body (x: decode_body): decode_body =
+        let aux (_: #aslVisitor) (x: decode_body): decode_body =
             (match x with
             | DecoderBody_UNPRED   _ -> x
             | DecoderBody_UNALLOC  _ -> x
             | DecoderBody_NOP      _ -> x
             | DecoderBody_Encoding _ -> x
             | DecoderBody_Decoder (fs, c, loc) ->
-                    let c' = visit_decode_case vis c in
+                    let c' = self#visit_decode_case c in
                     if c == c' then x else DecoderBody_Decoder (fs, c', loc)
             )
         in
         doVisit vis (vis#vdbody x) aux x
 
-let visit_arg (vis: #aslVisitor) (x: (ty * ident)): (ty * ident) =
+    method visit_arg (x: (ty * ident)): (ty * ident) =
         (match x with
         | (ty, v) ->
-                let ty' = visit_type vis ty in
+                let ty' = self#visit_type ty in
                 let v'  = visit_var  vis v in
                 if ty == ty' && v == v' then x else
                 (ty', v')
         )
 
-let visit_args (vis: #aslVisitor) (xs: (ty * ident) list): (ty * ident) list =
-        mapNoCopy (visit_arg vis) xs
+    method visit_args (xs: (ty * ident) list): (ty * ident) list =
+            mapNoCopy (self#visit_arg) xs
 
-let arg_of_sformal (sf: sformal): (ty * ident) =
-    match sf with
-    | Formal_In (ty, id)
-    | Formal_InOut (ty, id) -> (ty, id)
-
-let arg_of_ifield (IField_Field (id, _, wd)): (ty * ident) =
-    (Type_Bits (Expr_LitInt (string_of_int wd)), id)
-
-let args_of_encoding (Encoding_Block (_, _, fs, _, _, _, _, _)): (ty * ident) list =
-    List.map arg_of_ifield fs
-
-let visit_decl (vis: #aslVisitor) (x: declaration): declaration =
-        let aux (vis: #aslVisitor) (x: declaration): declaration =
+    method visit_decl (x: declaration): declaration =
+        let aux (_: #aslVisitor) (x: declaration): declaration =
             (match x with
             | Decl_BuiltinType (v, loc) ->
-                    let v'  = visit_var vis v in
+                    let v'  = self#visit_var v in
                     if v == v' then x else
                     Decl_BuiltinType (v', loc)
             | Decl_Forward (v, loc) ->
-                    let v'  = visit_var vis v in
+                    let v'  = self#visit_var v in
                     if v == v' then x else
                     Decl_Forward (v', loc)
             | Decl_Record (v, fs, loc) ->
-                    let v'  = visit_var vis v in
-                    let fs' = visit_args vis fs in
+                    let v'  = self#visit_var v in
+                    let fs' = self#visit_args fs in
                     if v == v' && fs == fs' then x else
                     Decl_Record (v', fs', loc)
             | Decl_Typedef (v, ty, loc) ->
-                    let v'  = visit_var vis v in
-                    let ty' = visit_type vis ty in
+                    let v'  = self#visit_var v in
+                    let ty' = self#visit_type ty in
                     if v == v' && ty == ty' then x else
                     Decl_Typedef (v', ty', loc)
             | Decl_Enum (v, es, loc) ->
-                    let v'  = visit_var vis v in
-                    let es' = mapNoCopy (visit_var vis) es in
+                    let v'  = self#visit_var v in
+                    let es' = mapNoCopy (self#visit_var) es in
                     if v == v' && es == es' then x else
                     Decl_Enum (v', es', loc)
             | Decl_Var (ty, v, loc) ->
-                    let ty' = visit_type vis ty in
-                    let v'  = visit_var vis v in
+                    let ty' = self#visit_type ty in
+                    let v'  = self#visit_var v in
                     if ty == ty' && v == v' then x else
                     Decl_Var (ty', v', loc)
             | Decl_Const (ty, v, e, loc) ->
-                    let ty' = visit_type vis ty in
-                    let v'  = visit_var vis v in
-                    let e'  = visit_expr vis e in
+                    let ty' = self#visit_type ty in
+                    let v'  = self#visit_var v in
+                    let e'  = self#visit_expr e in
                     if ty == ty' && v == v' && e == e' then x else
                     Decl_Const (ty', v', e', loc)
             | Decl_BuiltinFunction (ty, f, args, loc) ->
-                    let ty'   = visit_type vis ty in
-                    let f'    = visit_var vis f in
-                    let args' = visit_args vis args in
+                    let ty'   = self#visit_type ty in
+                    let f'    = self#visit_var f in
+                    let args' = self#visit_args args in
                     if ty == ty' && f == f' && args == args' then x else
                     Decl_BuiltinFunction (ty', f', args', loc)
             | Decl_FunType (ty, f, args, loc) ->
-                    let ty'   = visit_type vis ty in
-                    let f'    = visit_var vis f in
-                    let args' = visit_args vis args in
+                    let ty'   = self#visit_type ty in
+                    let f'    = self#visit_var f in
+                    let args' = self#visit_args args in
                     if ty == ty' && f == f' && args == args' then x else
                     Decl_FunType (ty', f', args', loc)
             | Decl_FunDefn (ty, f, args, b, loc) ->
-                    let ty'   = visit_type vis ty in
-                    let f'    = visit_var vis f in
-                    let args' = visit_args vis args in
-                    let b'    = with_locals args' vis visit_stmts b in
+                    let ty'   = self#visit_type ty in
+                    let f'    = self#visit_var f in
+                    let args' = self#visit_args args in
+                    let b'    = self#with_locals args' self#visit_stmts b in
                     if ty == ty' && f == f' && args == args' && b == b' then x else
                     Decl_FunDefn (ty', f', args', b', loc)
             | Decl_ProcType (f, args, loc) ->
-                    let f'    = visit_var vis f in
-                    let args' = visit_args vis args in
+                    let f'    = self#visit_var f in
+                    let args' = self#visit_args args in
                     if f == f' && args == args' then x else
                     Decl_ProcType (f', args', loc)
             | Decl_ProcDefn (f, args, b, loc) ->
-                    let f'    = visit_var vis f in
-                    let args' = visit_args vis args in
-                    let b'    = with_locals args' vis visit_stmts b in
+                    let f'    = self#visit_var f in
+                    let args' = self#visit_args args in
+                    let b'    = self#with_locals args' self#visit_stmts b in
                     if f == f' && args == args' && b == b' then x else
                     Decl_ProcDefn (f', args', b', loc)
             | Decl_VarGetterType (ty, f, loc) ->
-                    let ty' = visit_type vis ty in
-                    let f'  = visit_var vis f in
+                    let ty' = self#visit_type ty in
+                    let f'  = self#visit_var f in
                     if ty == ty' && f == f' then x else
                     Decl_VarGetterType (ty', f', loc)
             | Decl_VarGetterDefn (ty, f, b, loc) ->
-                    let ty' = visit_type vis ty in
-                    let f'  = visit_var vis f in
-                    let b'  = visit_stmts vis b in
+                    let ty' = self#visit_type ty in
+                    let f'  = self#visit_var f in
+                    let b'  = self#visit_stmts b in
                     if ty == ty' && f == f' && b == b' then x else
                     Decl_VarGetterDefn (ty', f', b', loc)
             | Decl_ArrayGetterType (ty, f, args, loc) ->
-                    let ty'   = visit_type vis ty in
-                    let f'    = visit_var vis f in
-                    let args' = visit_args vis args in
+                    let ty'   = self#visit_type ty in
+                    let f'    = self#visit_var f in
+                    let args' = self#visit_args args in
                     if ty == ty' && f == f' && args == args' then x else
                     Decl_ArrayGetterType (ty', f', args', loc)
             | Decl_ArrayGetterDefn (ty, f, args, b, loc) ->
-                    let ty'   = visit_type vis ty in
-                    let f'    = visit_var vis f in
-                    let args' = visit_args vis args in
-                    let b'    = with_locals args' vis visit_stmts b in
+                    let ty'   = self#visit_type ty in
+                    let f'    = self#visit_var f in
+                    let args' = self#visit_args args in
+                    let b'    = self#with_locals args' self#visit_stmts b in
                     if ty == ty' && f == f' && args == args' && b == b' then x else
                     Decl_ArrayGetterDefn (ty', f', args', b', loc)
             | Decl_VarSetterType (f, ty, v, loc) ->
-                    let f'  = visit_var vis f in
-                    let ty' = visit_type vis ty in
-                    let v'  = visit_var vis v in
+                    let f'  = self#visit_var f in
+                    let ty' = self#visit_type ty in
+                    let v'  = self#visit_var v in
                     if f == f' && ty == ty' && v == v' then x else
                     Decl_VarSetterType (f', ty', v', loc)
             | Decl_VarSetterDefn (f, ty, v, b, loc) ->
-                    let f'  = visit_var vis f in
-                    let ty' = visit_type vis ty in
-                    let v'  = visit_var vis v in
-                    let b'  = with_locals [(ty', v')] vis visit_stmts b in
+                    let f'  = self#visit_var f in
+                    let ty' = self#visit_type ty in
+                    let v'  = self#visit_var v in
+                    let b'  = self#with_locals [(ty', v')] self#visit_stmts b in
                     if f == f' && ty == ty' && v == v' && b == b' then x else
                     Decl_VarSetterDefn (f', ty', v', b', loc)
             | Decl_ArraySetterType (f, args, ty, v, loc) ->
-                    let f'    = visit_var vis f in
-                    let args' = mapNoCopy (visit_sformal vis) args in
-                    let ty'   = visit_type vis ty in
-                    let v'    = visit_var vis v in
+                    let f'    = self#visit_var f in
+                    let args' = mapNoCopy (self#visit_sformal) args in
+                    let ty'   = self#visit_type ty in
+                    let v'    = self#visit_var v in
                     if f == f' && args == args' && ty == ty' && v == v' then x else
                     Decl_ArraySetterType (f', args', ty', v', loc)
             | Decl_ArraySetterDefn (f, args, ty, v, b, loc) ->
-                    let f'    = visit_var vis f in
-                    let args' = mapNoCopy (visit_sformal vis) args in
-                    let ty'   = visit_type vis ty in
-                    let v'    = visit_var vis v in
+                    let f'    = self#visit_var f in
+                    let args' = mapNoCopy (self#visit_sformal) args in
+                    let ty'   = self#visit_type ty in
+                    let v'    = self#visit_var v in
                     let lvars = List.map arg_of_sformal args' @ [(ty', v')] in
-                    let b'    = with_locals lvars vis visit_stmts b in
+                    let b'    = self#with_locals lvars self#visit_stmts b in
                     if f == f' && args == args' && ty == ty' && v == v' && b == b' then x else
                     Decl_ArraySetterDefn (f', args', ty', v', b', loc)
             | Decl_InstructionDefn (d, es, opd, c, ex, loc) ->
-                    let d'    = visit_var vis d in
-                    let es'   = mapNoCopy (visit_encoding vis) es in
+                    let d'    = self#visit_var d in
+                    let es'   = mapNoCopy (self#visit_encoding) es in
                     let lvars = List.concat (List.map args_of_encoding es) in
-                    let opd'  = mapOptionNoCopy (with_locals lvars vis visit_stmts) opd in
-                    let ex'   = with_locals lvars vis visit_stmts ex in
+                    let opd'  = mapOptionNoCopy (self#with_locals lvars self#visit_stmts) opd in
+                    let ex'   = self#with_locals lvars self#visit_stmts ex in
                     if d == d' && es == es' && opd == opd' && ex == ex' then x else
                     Decl_InstructionDefn (d', es', opd', c, ex', loc)
             | Decl_DecoderDefn (d, dc, loc) ->
-                    let d'  = visit_var vis d in
-                    let dc' = visit_decode_case vis dc in
+                    let d'  = self#visit_var d in
+                    let dc' = self#visit_decode_case dc in
                     if d == d' && dc == dc' then x else
                     Decl_DecoderDefn (d', dc', loc)
             | Decl_Operator1 (op, vs, loc) ->
-                    let vs' = mapNoCopy (visit_var vis) vs in
+                    let vs' = mapNoCopy (self#visit_var) vs in
                     if vs == vs' then x else
                     Decl_Operator1 (op, vs', loc)
             | Decl_Operator2 (op, vs, loc) ->
-                    let vs' = mapNoCopy (visit_var vis) vs in
+                    let vs' = mapNoCopy (self#visit_var) vs in
                     if vs == vs' then x else
                     Decl_Operator2 (op, vs', loc)
             | Decl_NewEventDefn(v, args, loc) ->
-                    let v'    = visit_var vis v in
-                    let args' = visit_args vis args in
+                    let v'    = self#visit_var v in
+                    let args' = self#visit_args args in
                     if v == v' && args == args' then x else
                     Decl_NewEventDefn(v', args', loc)
             | Decl_EventClause(v, b, loc) ->
-                    let v'  = visit_var vis v in
-                    let b'  = visit_stmts vis b in
+                    let v'  = self#visit_var v in
+                    let b'  = self#visit_stmts b in
                     if v == v' && b == b' then x else
                     Decl_EventClause(v', b', loc)
             | Decl_NewMapDefn(ty, v, args, b, loc) ->
-                    let ty'   = visit_type vis ty in
-                    let v'    = visit_var vis v in
-                    let args' = visit_args vis args in
-                    let b'    = with_locals args' vis visit_stmts b in
+                    let ty'   = self#visit_type ty in
+                    let v'    = self#visit_var v in
+                    let args' = self#visit_args args in
+                    let b'    = self#with_locals args' self#visit_stmts b in
                     if v == v' && args == args' && b == b' then x else
                     Decl_NewMapDefn(ty', v', args', b', loc)
             | Decl_MapClause(v, fs, oc, b, loc) ->
-                    let v'  = visit_var vis v in
-                    let fs' = mapNoCopy (visit_mapfield vis) fs in
-                    let oc' = mapOptionNoCopy (visit_expr vis) oc in
-                    let b'  = visit_stmts vis b in
+                    let v'  = self#visit_var v in
+                    let fs' = mapNoCopy (self#visit_mapfield) fs in
+                    let oc' = mapOptionNoCopy (self#visit_expr) oc in
+                    let b'  = self#visit_stmts b in
                     if v == v' && fs == fs' && oc == oc' && b == b' then x else
                     Decl_MapClause(v', fs', oc', b', loc)
             | Decl_Config(ty, v, e, loc) ->
-                    let ty' = visit_type vis ty in
-                    let v'  = visit_var vis v in
-                    let e'  = visit_expr vis e in
+                    let ty' = self#visit_type ty in
+                    let v'  = self#visit_var v in
+                    let e'  = self#visit_expr e in
                     if ty == ty' && v == v' && e == e' then x else
                     Decl_Config(ty', v', e', loc)
             )
 
         in
         doVisit vis (vis#vdecl x) aux x
+end
 
 
 (****************************************************************)

--- a/libASL/asl_visitor.ml
+++ b/libASL/asl_visitor.ml
@@ -310,7 +310,7 @@ class aslTreeVisitor (vis: #aslVisitor) = object(self)
         vis#leave_scope ();
         stmts'
 
-    method with_locals (ls: ((ty * ident) list)) (f: 'a -> 'b) (x: 'a): 'b =
+    method with_locals : 'a 'b. (ty * ident) list -> ('a -> 'b) -> 'a -> 'b = fun ls f x ->
         vis#enter_scope ls;
         let result = f x in
         vis#leave_scope ();
@@ -531,7 +531,7 @@ class aslTreeVisitor (vis: #aslVisitor) = object(self)
         (match x with
         | (ty, v) ->
                 let ty' = self#visit_type ty in
-                let v'  = visit_var  vis v in
+                let v'  = self#visit_var v in
                 if ty == ty' && v == v' then x else
                 (ty', v')
         )
@@ -715,6 +715,62 @@ class aslTreeVisitor (vis: #aslVisitor) = object(self)
         in
         doVisit vis (vis#vdecl x) aux x
 end
+
+(* convenience methods to visit with the ordinary forwards aslTreeVisitor. *)
+
+let visit_exprs (vis: #aslVisitor) : expr list -> expr list = (new aslTreeVisitor vis)#visit_exprs
+
+let visit_var (vis: #aslVisitor) : ident -> ident = (new aslTreeVisitor vis)#visit_var
+
+let visit_lvar (vis: #aslVisitor) : ident -> ident = (new aslTreeVisitor vis)#visit_lvar
+
+let visit_e_elsif (vis: #aslVisitor) : e_elsif -> e_elsif = (new aslTreeVisitor vis)#visit_e_elsif
+
+let visit_slice (vis: #aslVisitor) : slice -> slice = (new aslTreeVisitor vis)#visit_slice
+
+let visit_patterns (vis: #aslVisitor) : pattern list -> pattern list = (new aslTreeVisitor vis)#visit_patterns
+
+let visit_pattern (vis: #aslVisitor) : pattern -> pattern = (new aslTreeVisitor vis)#visit_pattern
+
+let visit_expr (vis: #aslVisitor) : expr -> expr = (new aslTreeVisitor vis)#visit_expr
+
+let visit_types (vis: #aslVisitor) : ty list -> ty list = (new aslTreeVisitor vis)#visit_types
+
+let visit_type (vis: #aslVisitor) : ty -> ty = (new aslTreeVisitor vis)#visit_type
+
+let visit_lexprs (vis: #aslVisitor) : lexpr list -> lexpr list = (new aslTreeVisitor vis)#visit_lexprs
+
+let visit_lexpr (vis: #aslVisitor) : lexpr -> lexpr = (new aslTreeVisitor vis)#visit_lexpr
+
+let visit_stmts (vis: #aslVisitor) : stmt list -> stmt list = (new aslTreeVisitor vis)#visit_stmts
+
+let visit_stmt (vis: #aslVisitor) : stmt -> stmt = (new aslTreeVisitor vis)#visit_stmt
+
+let visit_s_elsif (vis: #aslVisitor) : s_elsif -> s_elsif = (new aslTreeVisitor vis)#visit_s_elsif
+
+let visit_alt (vis: #aslVisitor) : alt -> alt = (new aslTreeVisitor vis)#visit_alt
+
+let visit_catcher (vis: #aslVisitor) : catcher -> catcher = (new aslTreeVisitor vis)#visit_catcher
+
+let visit_mapfield (vis: #aslVisitor) : mapfield -> mapfield = (new aslTreeVisitor vis)#visit_mapfield
+
+let visit_sformal (vis: #aslVisitor) : sformal -> sformal = (new aslTreeVisitor vis)#visit_sformal
+
+let visit_dpattern (vis: #aslVisitor) : decode_pattern -> decode_pattern = (new aslTreeVisitor vis)#visit_dpattern
+
+let visit_encoding (vis: #aslVisitor) : encoding -> encoding = (new aslTreeVisitor vis)#visit_encoding
+
+let visit_decode_case (vis: #aslVisitor) : decode_case -> decode_case = (new aslTreeVisitor vis)#visit_decode_case
+
+let visit_decode_alt (vis: #aslVisitor) : decode_alt -> decode_alt = (new aslTreeVisitor vis)#visit_decode_alt
+
+let visit_decode_body (vis: #aslVisitor) : decode_body -> decode_body = (new aslTreeVisitor vis)#visit_decode_body
+
+let visit_arg (vis: #aslVisitor) : (ty * ident) -> (ty * ident) = (new aslTreeVisitor vis)#visit_arg
+
+let visit_args (vis: #aslVisitor) : (ty * ident) list -> (ty * ident) list = (new aslTreeVisitor vis)#visit_args
+
+let visit_decl (vis: #aslVisitor) : declaration -> declaration = (new aslTreeVisitor vis)#visit_decl
 
 
 (****************************************************************)

--- a/libASL/offline_opt.ml
+++ b/libASL/offline_opt.ml
@@ -273,10 +273,10 @@ module CopyProp = struct
     method! vstmt = function
       (* Transform runtime variable decls into expression decls *)
       | Stmt_ConstDecl(t, v, Expr_TApply(f, [], args), loc) when is_var_decl f && candidate_var v st ->
-          ChangeDoChildrenPost(Stmt_VarDeclsNoInit(Offline_transform.rt_expr_ty, [v], loc), fun e -> e)
+          ChangeDoChildrenPost([Stmt_VarDeclsNoInit(Offline_transform.rt_expr_ty, [v], loc)], fun e -> e)
       (* Transform stores into assigns *)
       | Stmt_TCall(f, [], [Expr_Var v; e], loc) when is_var_store f && candidate_var v st ->
-          ChangeDoChildrenPost(Stmt_Assign(LExpr_Var v, e, loc), fun e -> e)
+          ChangeDoChildrenPost([Stmt_Assign(LExpr_Var v, e, loc)], fun e -> e)
       | _ -> DoChildren
   end
 

--- a/libASL/symbolic_lifter.ml
+++ b/libASL/symbolic_lifter.ml
@@ -83,7 +83,7 @@ module RemoveUnsupported = struct
     inherit Asl_visitor.nopAslVisitor
 
     method! vstmt e =
-      (match e with
+      singletonVisitAction (match e with
       | Stmt_Assert(e, loc) ->
           if contains_unsupported e unsupported env then ChangeTo (assert_false loc)
           else DoChildren
@@ -207,7 +207,7 @@ module Cleanup = struct
             (RemoveUnsupported.assert_false loc)
           else e
       | _ -> e) in
-      ChangeDoChildrenPost(e, reduce)
+      singletonVisitAction @@ ChangeDoChildrenPost(e, reduce)
   end
 
   let rec trim_post_term stmts =
@@ -277,7 +277,7 @@ module DecoderCleanup = struct
             (RemoveUnsupported.assert_false loc)
           else e
       | _ -> e) in
-      ChangeDoChildrenPost(e, reduce)
+      singletonVisitAction @@ ChangeDoChildrenPost(e, reduce)
   end
 
   let run unsupported dsig =


### PR DESCRIPTION
This adds a visitor suitable for basic backwards analyses. In doing so, we refactor the visit\_\* functions to place them inside a class. This makes it possible to override one or more of the methods, as we do in aslBackwardsVisitor for visit\_stmts.

The backwards visitor has the same limitations as the existing forwards visitor. That is, merging results at control flow joins is difficult to do. However, for simple analyses, this can be worked around with careful use of enter/exit scope.

There is naming confusion in aslVisitor / aslForwardsVisitor / aslBackwardsVisitor which would be good to fix. aslVisitor defines the visit actions for specific AST nodes, whereas the aslForwardsVisitor/aslBackwardsVisitor applies these recursively in a particular order. Maybe these can be called aslForwardsTransform...?