### PR TITLE
ci: add magic nix cache.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
 
     - uses: cachix/install-nix-action@v25
     - uses: DeterminateSystems/magic-nix-cache-action@main
+      with:
+        upstream-cache: https://nowhere.example.com # we want to cache from cache.nixos.org.
 
     - run: echo 'preparing nix shell environment'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,8 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: cachix/install-nix-action@v25
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+
     - run: echo 'preparing nix shell environment'
 
     - run: dune build --profile release


### PR DESCRIPTION
this might (or might not) speed up github builds by using a cache hosted by github. in any case, the speedup would be marginal.