### PR TITLE
ci: add offline-coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,7 @@ jobs:
     - run: dune build --profile release
     - run: dune runtest -j4
     - run: dune build '@coverage' -j4
+    - run: dune build '@offline-coverage' -j4
     - run: |
         echo "OUTPUT=$(pwd)/_build/default/tests/coverage" >> $GITHUB_OUTPUT
         rm -rf _build/default/tests/coverage/encodings


### PR DESCRIPTION
it would be useful to run the offline generators of other backends as well. beyond that, i am not sure if compiling the generated backends would be a useful/possible thing to do (esp. if they require additional dependencies).