### PR TITLE
support -x 0 to print encoding name.

### DIFF
--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -26,7 +26,7 @@ let opt_no_default_aarch64 = ref false
 let opt_print_aarch64_dir = ref false
 let opt_verbose = ref false
 
-let opt_debug_level = ref 0
+let opt_debug_level = ref (-1)
 
 
 let () = Printexc.register_printer
@@ -319,7 +319,7 @@ let rec repl (tcenv: TC.Env.t) (cpu: Cpu.cpu): unit =
     )
 
 let options = Arg.align ([
-    ( "-x", Arg.Set_int opt_debug_level,      "       Debugging output");
+    ( "-x", Arg.Set_int opt_debug_level,      "       Partial evaluation debugging (requires debug level argument >= 0)");
     ( "-v", Arg.Set opt_verbose,              "       Verbose output");
     ( "--no-aarch64", Arg.Set opt_no_default_aarch64 , "       Disable bundled AArch64 semantics");
     ( "--aarch64-dir", Arg.Set opt_print_aarch64_dir, "       Print directory of bundled AArch64 semantics");

--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -1427,8 +1427,8 @@ and dis_decode_alt' (loc: AST.l) (DecoderAlt_Alt (ps, b)) (vs: value list) (op: 
                 let@ enc_match = dis_encoding enc op in
                 if enc_match then begin
                     (* todo: should evaluate ConditionHolds to decide whether to execute body *)
-                    if !debug_level >= 1 then begin
-                        Printf.printf "Dissasm: %s\n" (pprint_ident inst);
+                    if !debug_level >= 0 then begin
+                        Printf.printf "Disasm: %s\n" (pprint_ident inst);
                     end;
 
                     let@ (lenv',stmts) = DisEnv.locally_ (


### PR DESCRIPTION
this is very useful when looking for the name of an encoding, without cluttering the output with the disassembly trace.

the default debug_level has been lowered to -1 to support -x 0 as a non-default level. we cannot print by default since that would clutter stdout when used as a library.

example:
```bash
$ echo ':sem A64 0xd4207d00' | dune exec asli -- -x 0
Decoding instruction A64 d4207d00     
Disasm: aarch64_system_exceptions_debug_breakpoint
BTypeCompatible = TRUE ;
assert FALSE ;
```