### PR TITLE
correctly set default debug-level to no debugging output.

### DIFF
--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -26,8 +26,6 @@ let opt_no_default_aarch64 = ref false
 let opt_print_aarch64_dir = ref false
 let opt_verbose = ref false
 
-let opt_debug_level = ref (-1)
-
 
 let () = Printexc.register_printer
     (function
@@ -319,7 +317,7 @@ let rec repl (tcenv: TC.Env.t) (cpu: Cpu.cpu): unit =
     )
 
 let options = Arg.align ([
-    ( "-x", Arg.Set_int opt_debug_level,      "       Partial evaluation debugging (requires debug level argument >= 0)");
+    ( "-x", Arg.Set_int Dis.debug_level,      "       Partial evaluation debugging (requires debug level argument >= 0)");
     ( "-v", Arg.Set opt_verbose,              "       Verbose output");
     ( "--no-aarch64", Arg.Set opt_no_default_aarch64 , "       Disable bundled AArch64 semantics");
     ( "--aarch64-dir", Arg.Set opt_print_aarch64_dir, "       Print directory of bundled AArch64 semantics");
@@ -374,7 +372,6 @@ let main () =
         if not !opt_no_default_aarch64 then
             opt_filenames := snd (Option.get aarch64_asl_files); (* (!) should be safe if environment built successfully. *)
         if !opt_verbose then Printf.printf "Built evaluation environment\n";
-        Dis.debug_level := !opt_debug_level;
 
         LNoise.history_load ~filename:"asl_history" |> ignore;
         LNoise.history_set ~max_length:100 |> ignore;

--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -24,9 +24,10 @@ end
 module StringMap = Map.Make(StringCmp)
 
 
-let debug_level = ref 0
+let debug_level_none = -1
+let debug_level = ref debug_level_none
 let debug_show_trace = ref false
-let no_debug = fun () -> !debug_level = 0
+let no_debug = fun () -> !debug_level <= debug_level_none
 
 (** (name, arg, location) tuple for tracing disassembly calls.
     For example: ("dis_expr", "1+1", loc).


### PR DESCRIPTION
this unifies the debug level option into the Dis module. previously, due to discrepancies between the debug level in the Asli and Dis modules, the debug level would be non-silent in gtirb-semantics.

this also speeds up the performance by fixing the no_debug check.