### PR TITLE
support non 32-bit length opcodes

### DIFF
--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -127,7 +127,7 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
                 let lenv = Dis.build_env disEnv in
 
                 let opcode = input_line inchan in
-                let op = Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) (Z.of_int (int_of_string opcode))) in
+                let op = Z.of_string opcode in
 
                 (* Printf.printf "PRE Eval env: %s\n\n" (Testing.pp_eval_env evalEnv);
                 Printf.printf "PRE Dis eval env: %s\n\n" (Testing.pp_eval_env disEvalEnv); *)
@@ -197,7 +197,7 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
         Printf.printf "Decoding instruction %s %s\n" iset (Z.format "%x" op);
         cpu'.sem iset op
     | ":ast" :: iset :: opcode :: rest when List.length rest <= 1 ->
-        let op = Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) (Z.of_string opcode)) in
+        let op = Z.of_string opcode in
         let decoder = Eval.Env.getDecoder cpu.env (Ident iset) in
         let chan_opt = Option.map open_out (List.nth_opt rest 0) in
         let chan = Option.value chan_opt ~default:stdout in
@@ -226,9 +226,8 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
         in
         let cpu' = Cpu.mkCPU (Eval.Env.copy cpu.env) cpu.denv in
         let op = Z.of_string opcode in
-        let bits = VBits (Primops.prim_cvt_int_bits (Z.of_int 32) op) in
         let decoder = Eval.Env.getDecoder cpu'.env (Ident iset) in
-        let stmts = Dis.dis_decode_entry cpu'.env cpu.denv decoder bits in
+        let stmts = Dis.dis_decode_entry cpu'.env cpu.denv decoder op in
         let chan = open_out_bin fname in
         Printf.printf "Dumping instruction semantics for %s %s" iset (Z.format "%x" op);
         Printf.printf " to file %s\n" fname;

--- a/bin/offline_coverage.ml
+++ b/bin/offline_coverage.ml
@@ -18,7 +18,7 @@ let op_dis (op: int): stmt list opresult =
     | e -> Result.Error (Op_DisFail e)
 
 let op_test_opcode (env: Env.t) (iset: string) (op: int): Env.t opresult =
-  let op' = Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) (Z.of_int op)) in
+  let op' = Z.of_int op in
 
   let initenv = Env.copy env in
   Random.self_init ();

--- a/libASL/cpu.ml
+++ b/libASL/cpu.ml
@@ -51,16 +51,14 @@ let mkCPU (env : Eval.Env.t) (denv: Dis.env): cpu =
         Eval.eval_proccall loc env (AST.FIdent ("__ELFWriteMemory", 0)) [] [a; b]
 
     and opcode (iset: string) (opcode: Primops.bigint): unit =
-        let op = Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) opcode) in
         let decoder = Eval.Env.getDecoder env (Ident iset) in
-        Eval.eval_decode_case AST.Unknown env decoder op
+        Eval.eval_decode_case AST.Unknown env decoder opcode
 
     and sem (iset: string) (opcode: Primops.bigint): unit =
-        let op = Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) opcode) in
         let decoder = Eval.Env.getDecoder env (Ident iset) in
         List.iter
             (fun s -> Printf.printf "%s\n" (pp_stmt s))
-            (Dis.dis_decode_entry env denv decoder op)
+            (Dis.dis_decode_entry env denv decoder opcode)
 
     and gen (iset: string) (pat: string) (backend: gen_backend) (dir: string): unit =
         if not (Sys.file_exists dir) then failwith ("Can't find target dir " ^ dir);

--- a/libASL/eval.ml
+++ b/libASL/eval.ml
@@ -520,12 +520,24 @@ let removeGlobalConsts (env: Env.t) (ids: IdentSet.t): IdentSet.t =
 (****************************************************************)
 
 (** Evaluate bitslice of instruction opcode *)
-let eval_decode_slice (loc: l) (env: Env.t) (x: decode_slice) (op: value): value =
+let eval_decode_slice (loc: l) (env: Env.t) (x: decode_slice) (op: Primops.bigint): value =
     (match x with
-    | DecoderSlice_Slice (lo, wd) -> extract_bits' loc op lo wd
+    | DecoderSlice_Slice (lo, wd) ->
+        let op = Value.from_bitsInt (lo+wd) op in
+        extract_bits' loc op lo wd
     | DecoderSlice_FieldName f -> Env.getVar loc env f
     | DecoderSlice_Concat fs -> eval_concat loc (List.map (Env.getVar loc env) fs)
     )
+
+(** Evaluate an encoding's opcode guard pattern *)
+let eval_opcode_guard (loc: AST.l) (x: opcode_value) (op: Primops.bigint): value option =
+    let opcode_val, eval_opcode = (match x with
+    | Opcode_Bits b -> (from_bitsLit b, eval_eq)
+    | Opcode_Mask m -> (from_maskLit m, eval_inmask)
+    ) in
+    let opcode_len = length_bits loc opcode_val in
+    let op = from_bitsInt opcode_len op in
+    if eval_opcode loc op opcode_val then Some op else None
 
 (** Evaluate instruction decode pattern match *)
 let rec eval_decode_pattern (loc: AST.l) (x: decode_pattern) (op: value): bool =
@@ -910,7 +922,8 @@ and eval_stmt (env: Env.t) (x: AST.stmt): unit =
     | Stmt_DecodeExecute(i, e, loc) ->
             let dec = Env.getDecoder env i in
             let op  = eval_expr loc env e in
-            eval_decode_case loc env dec op
+            let value = (to_bits loc op).v in
+            eval_decode_case loc env dec value
     | Stmt_If(c, t, els, e, loc) ->
             let rec eval css d =
                 (match css with
@@ -1055,7 +1068,7 @@ and eval_proccall (loc: l) (env: Env.t) (f: ident) (tvs: value list) (vs: value 
     )
 
 (** Evaluate instruction decode case *)
-and eval_decode_case (loc: AST.l) (env: Env.t) (x: decode_case) (op: value): unit =
+and eval_decode_case (loc: AST.l) (env: Env.t) (x: decode_case) (op: Primops.bigint): unit =
     (match x with
     | DecoderCase_Case (ss, alts, loc) ->
             let vs = List.map (fun s -> eval_decode_slice loc env s op) ss in
@@ -1074,7 +1087,7 @@ and eval_decode_case (loc: AST.l) (env: Env.t) (x: decode_case) (op: value): uni
     )
 
 (** Evaluate instruction decode case alternative *)
-and eval_decode_alt (loc: AST.l) (env: Env.t) (DecoderAlt_Alt (ps, b)) (vs: value list) (op: value): bool =
+and eval_decode_alt (loc: AST.l) (env: Env.t) (DecoderAlt_Alt (ps, b)) (vs: value list) (op: Primops.bigint): bool =
     if List.for_all2 (eval_decode_pattern loc) ps vs then
         (match b with
         | DecoderBody_UNPRED loc -> raise (Throw (loc, Exc_Unpredictable))
@@ -1096,6 +1109,7 @@ and eval_decode_alt (loc: AST.l) (env: Env.t) (DecoderAlt_Alt (ps, b)) (vs: valu
         | DecoderBody_Decoder (fs, c, loc) ->
                 (* let env = Env.empty in  *)
                 List.iter (function (IField_Field (f, lo, wd)) ->
+                    let op = Value.from_bitsInt (lo+wd) op in
                     Env.addLocalVar loc env f (extract_bits' loc op lo wd)
                 ) fs;
                 eval_decode_case loc env c op;
@@ -1105,7 +1119,7 @@ and eval_decode_alt (loc: AST.l) (env: Env.t) (DecoderAlt_Alt (ps, b)) (vs: valu
         false
 
 (** Evaluates instruction but draw statements from list, not specification *)
-and eval_stmt_case (loc: AST.l) (env: Env.t) (x: decode_case) (op: value) (xs: stmt list): unit =
+and eval_stmt_case (loc: AST.l) (env: Env.t) (x: decode_case) (op: Primops.bigint) (xs: stmt list): unit =
     (match x with
     | DecoderCase_Case (ss, alts, loc) ->
             let vs = List.map (fun s -> eval_decode_slice loc env s op) ss in
@@ -1123,7 +1137,7 @@ and eval_stmt_case (loc: AST.l) (env: Env.t) (x: decode_case) (op: value) (xs: s
             eval alts
     )
 
-and eval_stmt_alt (loc: AST.l) (env: Env.t) (DecoderAlt_Alt (ps, b)) (vs: value list) (op: value) (xs: stmt list): bool =
+and eval_stmt_alt (loc: AST.l) (env: Env.t) (DecoderAlt_Alt (ps, b)) (vs: value list) (op: Primops.bigint) (xs: stmt list): bool =
     if List.for_all2 (eval_decode_pattern loc) ps vs then
         (match b with
         | DecoderBody_UNPRED loc -> raise (Throw (loc, Exc_Unpredictable))
@@ -1145,6 +1159,7 @@ and eval_stmt_alt (loc: AST.l) (env: Env.t) (DecoderAlt_Alt (ps, b)) (vs: value 
         | DecoderBody_Decoder (fs, c, loc) ->
                 (* let env = Env.empty in  *)
                 List.iter (function (IField_Field (f, lo, wd)) ->
+                    let op = Value.from_bitsInt (lo+wd) op in
                     Env.addLocalVar loc env f (extract_bits' loc op lo wd)
                 ) fs;
                 eval_decode_case loc env c op;
@@ -1154,15 +1169,12 @@ and eval_stmt_alt (loc: AST.l) (env: Env.t) (DecoderAlt_Alt (ps, b)) (vs: value 
         false
 
 (** Evaluate instruction encoding *)
-and eval_encoding (env: Env.t) (x: encoding) (op: value): bool =
+and eval_encoding (env: Env.t) (x: encoding) (op: Primops.bigint): bool =
     let Encoding_Block (nm, iset, fields, opcode, guard, unpreds, b, loc) = x in
     (* todo: consider checking iset *)
     (* Printf.printf "Checking opcode match %s == %s\n" (Utils.to_string (PP.pp_opcode_value opcode)) (pp_value op); *)
-    let ok = (match opcode with
-    | Opcode_Bits b -> eval_eq     loc op (from_bitsLit b)
-    | Opcode_Mask m -> eval_inmask loc op (from_maskLit m)
-    ) in
-    if ok then begin
+    match eval_opcode_guard loc opcode op with
+    | Some op -> 
         if !trace_instruction then Printf.printf "TRACE: instruction %s\n" (pprint_ident nm);
         List.iter (function (IField_Field (f, lo, wd)) ->
             let v = extract_bits' loc op lo wd in
@@ -1179,10 +1191,7 @@ and eval_encoding (env: Env.t) (x: encoding) (op: value): bool =
         end else begin
             false
         end
-    end else begin
-        false
-    end
-
+    | None -> false
 
 
 (****************************************************************)

--- a/libASL/value.ml
+++ b/libASL/value.ml
@@ -209,6 +209,9 @@ let from_realLit (x: AST.realLit): value =
     let denominator = Z.pow (Z.of_int 10) fracsz in
     VReal (Q.make numerator denominator)
 
+let from_bitsInt (wd: int) (x: Primops.bigint) =
+    VBits (Primops.mkBits wd x)
+
 let from_bitsLit (x: AST.bitsLit): value =
     let x' = drop_chars x ' ' in
     VBits (mkBits (String.length x') (Z.of_string_base 2 x'))
@@ -398,6 +401,10 @@ and prims_impure = ["ram_init"; "ram_read"; "ram_write"; "trace_memory_read"; "t
 (****************************************************************)
 (** {2 Utility functions on Values}                             *)
 (****************************************************************)
+
+let length_bits (loc: AST.l) = function
+    | VBits { n; _ } | VMask { n; _ } -> n
+    | x -> raise (EvalError (loc, "bits or mask expected. Got " ^ pp_value x))
 
 let extract_bits (loc: AST.l) (x: value) (i: value) (w: value): value =
     VBits (prim_extract (to_bits loc x) (to_integer loc i) (to_integer loc w))

--- a/tests/test_asl.ml
+++ b/tests/test_asl.ml
@@ -74,7 +74,7 @@ let test_compare env () : unit =
             let lenv = Dis.build_env disEnv in
 
             let opcode = input_line inchan in
-            let op = Value.VBits (Primops.prim_cvt_int_bits (Z.of_int 32) (Z.of_int (int_of_string opcode))) in
+            let op = Z.of_string opcode in
 
             (try
                 (* Evaluate original instruction *)


### PR DESCRIPTION
this retrofits the eval and dis modules to use a bigint for the opcode during the decode phase, supporting pcodes of arbitrary length and (potentially) variable-length opcodes.

once a particular encoding is identified through the decode tree, we convert the bigint to a fixed-width bitvector. this is then passed through to the rest of the evaluation / analysis.

this can be tested with the following ASL file:
```c
__instruction test1
    __encoding test
        __instruction_set TEST
        __opcode 'xxxxxxxx xxxxxxxx xxxxxxxx xxxxxxxx xxxx xxxx'
        __guard TRUE
        __decode

    __execute
        boolean something;

        bits(64) left = Zeros();
        bits(64) right = Zeros();

        if (left == right) then
            something = TRUE;
        else
            something = FALSE;

__decode TEST
    case (0 +: 4) of
        when (_) => __encoding test
```
run:
```
dune exec asli -- --no-aarch64 prelude.asl mra_tools/arch/regs.asl mra_tools/types.asl mra_tools/arch//arch.asl tests/test.asl
```

this 40-bit opcode will now decode successfully: `:sem TEST 0xffffeeeeff`. 