### PR TITLE
remove pcre library, use ocaml str instead

### DIFF
--- a/asli.opam
+++ b/asli.opam
@@ -24,7 +24,6 @@ depends: [
   "pprint"
   "zarith"
   "z3" {>= "4.8.7"}
-  "pcre"
   "alcotest" {with-test}
   "dune-site"
   "lwt"

--- a/bin/dune
+++ b/bin/dune
@@ -5,7 +5,7 @@
  (modes exe byte)
  (modules asli)
  (flags (-cclib -lstdc++))
- (libraries libASL libASL_native linenoise pprint pcre)
+ (libraries libASL libASL_native linenoise pprint)
  )
 
 (executable
@@ -14,7 +14,7 @@
  (modes exe)
  (modules server)
  (flags (-cclib -lstdc++))
- (libraries libASL libASL_native pprint pcre lwt.unix yojson cohttp-lwt cohttp-lwt-unix))
+ (libraries libASL libASL_native pprint lwt.unix yojson cohttp-lwt cohttp-lwt-unix))
 
 
 (executable

--- a/dune-project
+++ b/dune-project
@@ -23,7 +23,6 @@
     "pprint"
     "zarith"
     ("z3"        (>= "4.8.7"))
-    "pcre"
     ("alcotest"  :with-test)
     "dune-site"
     "lwt"

--- a/libASL/decoder_program.ml
+++ b/libASL/decoder_program.ml
@@ -116,10 +116,10 @@ let run iset pat env problematic =
 
   (* Find all matching instructions, pulled from testing.ml *)
   let decoder = Eval.Env.getDecoder env (Ident iset) in
-  let re = Pcre.regexp pat in
+  let re = Str.regexp pat in
   let filterfn = function
     | ((Encoding_Block (Ident nm, Ident is, _, _, _, _, _, _)),_,_,_) ->
-        is = iset && Pcre.pmatch ~rex:re nm && not (List.mem nm problematic)
+        is = iset && Str.string_match re nm 0 && not (List.mem nm problematic)
     | _ -> assert false
   in
   let encs = List.filter filterfn (Eval.Env.listInstructions env) in

--- a/libASL/dune
+++ b/libASL/dune
@@ -33,7 +33,7 @@
    offline_transform ocaml_backend dis_tc
    offline_opt
    )
- (libraries libASL_support (re_export libASL_ast) str pcre dune-site))
+ (libraries libASL_support (re_export libASL_ast) str dune-site))
 
 (generate_sites_module
  (module res)

--- a/libASL/testing.ml
+++ b/libASL/testing.ml
@@ -423,10 +423,10 @@ let op_test_opcode (env: Env.t) (iset: string) (op: int): Env.t opresult =
 let get_opcodes (opt_verbose: bool ref) (iset: string) (instr: string) (env: Env.t): (string * instr_field list * ((int * bool) list) option) list =
   if !opt_verbose then Printf.printf "Coverage for encoding %s\n" instr;
 
-  let re = Pcre.regexp instr in
+  let re = Str.regexp instr in
   let encoding_matches = function
       | (Encoding_Block (Ident nm, Ident is, _, _, _, _, _, _)) ->
-          is = iset && Pcre.pmatch ~rex:re nm
+          is = iset && Str.string_match re nm 0
       | _ -> assert false
   in
   let encs = List.map (fun (x,_,_,_) -> x) (Env.listInstructions env) in

--- a/tests/coverage/dune
+++ b/tests/coverage/dune
@@ -20,8 +20,10 @@
 (rule (with-stdout-to cov_branch  (run ./run "aarch64_branch.+")))
 (rule (with-stdout-to cov_float   (run ./run "aarch64_float_.+")))
 (rule (with-stdout-to cov_vector1 (run ./run "aarch64_vector_arithmetic_binary.+")))
-(rule (with-stdout-to cov_vector2 (run ./run "aarch64_vector_(?!arithmetic_binary).+")))
+(rule (with-stdout-to cov_vector2 (run ./run "aarch64_vector_\\(arithmetic_unary\\|[^a]\\).+")))
 (rule (with-stdout-to cov_memory  (run ./run "aarch64_memory_.+")))
+; note: cov_vector2 is intended to be every vector instruction that's not arithmetic_binary.
+; note ocaml Str regex syntax: https://ocaml.org/manual/5.2/api/Str.html
 
 (rule (alias coverage) (action (diff ./aarch64_integer cov_integer)))
 (rule (alias coverage) (action (diff ./aarch64_branch cov_branch)))
@@ -34,7 +36,7 @@
 (rule (with-stdout-to off_cov_branch  (run ./off_run "aarch64_branch.+")))
 (rule (with-stdout-to off_cov_float   (run ./off_run "aarch64_float_.+")))
 (rule (with-stdout-to off_cov_vector1 (run ./off_run "aarch64_vector_arithmetic_binary.+")))
-(rule (with-stdout-to off_cov_vector2 (run ./off_run "aarch64_vector_(?!arithmetic_binary).+")))
+(rule (with-stdout-to off_cov_vector2 (run ./off_run "aarch64_vector_\\(arithmetic_unary\\|[^a]\\).+")))
 (rule (with-stdout-to off_cov_memory  (run ./off_run "aarch64_memory_.+")))
 
 (rule (alias offline-coverage) (action (diff ./aarch64_integer off_cov_integer)))


### PR DESCRIPTION
PCRE relies on a shared library, precluding its use in Javascript. in this change, we use the standard ocaml "str" library instead. note, however, that this supports a smaller subscript of regex (notably no negative lookahead), and has a different syntax. 

see:
https://github.com/UQ-PAC/aslp/blob/75cf86fb7f5b4d6c753d021aad15faebd4ce2717/tests/coverage/dune#L19-L26

https://ocaml.org/manual/5.2/api/Str.html