### PR TITLE
readme: add instructions to install package with opam

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ This interpreter consists of a single directory organized as follows
 ASLp can be installed as a Nix package from https://github.com/katrinafyi/pac-nix.
 The _aslp_ provides ASLp bundled with ARM's specifications.
 If you don't plan on modifying the tool, this is a fast and easy way to get started.
+If installed via Nix, the following installation steps are not necessary.
 
 ### Installing dependencies
 
@@ -95,9 +96,17 @@ Platform specific instructions:
         sudo zypper install ocaml opam ocaml-ocaml-compiler-libs-devel
 ```
 
-Platform independent instructions:
+First-time only (if you have not previously set up an opam switch environment):
 
+```bash
+    opam init  # answer y/n depending on your preference
+    opam switch create ocaml.4.14.2  # or later
+    eval `opam env`
 ```
+
+Platform-independent instructions:
+
+```bash
     # Install dependencies from asli.opam file
     opam install --deps-only --with-test ./asli.opam
 
@@ -107,11 +116,9 @@ Platform independent instructions:
 
     # On OSX, you may need to use this command to install zarith
     env CFLAGS="-I$HOME/homebrew/include/" LDFLAGS="-L$HOME/homebrew/lib/" opam install zarith
-
-    eval `opam config env`
 ```
 
-You also need to execute this command
+You may also need to execute this command
 
 ```
     MacOS: export DYLD_LIBRARY_PATH=`opam config var z3:lib`
@@ -123,7 +130,7 @@ You also need to execute this command
 
 To build the ASL lexer and ASL interpreter, execute this command.
 
-``` 
+```
     make install
 ```
 
@@ -132,7 +139,7 @@ the right version.
 
 ### Building for use in other projects
 
-If you need to use ASLp or libASL in a downstream OCaml project,
+If you need to use ASLp or libASL as a dependency in another OCaml project,
 these steps will install the package in a location discoverable by opam and dune.
 
 After installing dependencies and testing the build, run these commands in this directory:

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This interpreter consists of a single directory organized as follows
 ### Installing with Nix
 
 ASLp can be installed as a Nix package from https://github.com/katrinafyi/pac-nix.
-_asli_ provides the base ASLp and _aslp_ provides ASLp bundled with ARM's specifications.
+The _aslp_ provides ASLp bundled with ARM's specifications.
 If you don't plan on modifying the tool, this is a fast and easy way to get started.
 
 ### Installing dependencies
@@ -123,12 +123,25 @@ You also need to execute this command
 
 To build the ASL lexer and ASL interpreter, execute this command.
 
-```
+``` 
     make install
 ```
 
 If you get a lot of linker errors involving Z3, double-check that you installed
 the right version.
+
+### Building for use in other projects
+
+If you need to use ASLp or libASL in a downstream OCaml project,
+these steps will install the package in a location discoverable by opam and dune.
+
+After installing dependencies and testing the build, run these commands in this directory:
+```
+    opam pin . -k path
+    opam install .
+```
+Once complete, you can verify the package is installed by running `ocamlfind query asli`.
+
 
 ### Using ASL lexer
 


### PR DESCRIPTION
This is necessary to compile OCaml projects dependent on aslp.