### PR TITLE
Series of Minor Fixes

### DIFF
--- a/libASL/dis_tc.ml
+++ b/libASL/dis_tc.ml
@@ -54,7 +54,6 @@ let prim_type fi targs =
   | ("mul_int",           [      ])     -> Some (Value.type_integer )
   | ("zdiv_int",          [      ])     -> Some (Value.type_integer )
   | ("zrem_int",          [      ])     -> Some (Value.type_integer )
-  | ("sdiv_int",          [      ])     -> Some (Value.type_integer )
   | ("fdiv_int",          [      ])     -> Some (Value.type_integer )
   | ("frem_int",          [      ])     -> Some (Value.type_integer )
   | ("mod_pow2_int",      [      ])     -> Some (Value.type_integer )

--- a/libASL/offline_opt.ml
+++ b/libASL/offline_opt.ml
@@ -37,7 +37,7 @@ let is_pure_expr f =
   match f with
   | FIdent(f, 0) when String.starts_with ~prefix f ->
       let f' = String.sub f 4 (String.length f - 4) in
-      List.mem f' Offline_transform.pure_prims
+      List.mem (FIdent(f',0)) Offline_transform.pure_prims
   | _ -> false
 
 let is_var_decl f =

--- a/libASL/offline_transform.ml
+++ b/libASL/offline_transform.ml
@@ -172,24 +172,14 @@ let join_state (a: state) (b: state): state =
   }
 
 (* Produce a runtime value if any arg is runtime *)
-let pure_prims =
-  Value.prims_pure @
-  (List.map fst (Dis.no_inline_pure ())) @ [
-    "lsr_bits";
-    "sle_bits";
-    "lsl_bits";
-    "asr_bits";
-    "slt_bits";
-    "sdiv_bits";
-  ]
+let pure_prims = Symbolic.prims_pure ()
 
 (* Prims that will always produce runtime *)
-let impure_prims =
-  List.map fst Dis.no_inline
+let impure_prims = Symbolic.prims_impure ()
 
 let prim_ops (f: ident) (targs: taint list) (args: taint list): taint option =
-  if List.mem (name_of_FIdent f) pure_prims then Some (join_taint_l (targs @ args))
-  else if List.mem (name_of_FIdent f) impure_prims then Some RunTime
+  if List.mem f pure_prims then Some (join_taint_l (targs @ args))
+  else if List.mem f impure_prims then Some RunTime
   else None
 
 (* Transfer function for a call, pulling a primop def or looking up registered fn signature.

--- a/libASL/scala_backend.ml
+++ b/libASL/scala_backend.ml
@@ -60,7 +60,7 @@ module StringSet = Set.Make(String)
         "f_gen_lsr_bits"; "f_gen_mul_bits"; "f_gen_ne_bits"; "f_gen_not_bits";
         "f_gen_not_bool"; "f_gen_or_bits"; "f_gen_or_bool"; "f_gen_sdiv_bits";
         "f_gen_sle_bits"; "f_gen_slt_bits"; "f_gen_sub_bits";
-        "f_gen_AArch64_MemTag_set"; "f_gen_Mem_read"; "f_gen_slice";
+        "f_gen_AArch64_MemTag_read"; "f_gen_AArch64_MemTag_set"; "f_gen_Mem_read"; "f_gen_slice";
         "f_gen_replicate_bits"; "f_gen_append_bits"; "f_gen_array_load";
         "f_gen_array_store"; "f_gen_Mem_set"; "f_gen_assert";
         "f_switch_context"; "f_true_branch"; "f_false_branch"; "f_merge_branch"])

--- a/libASL/symbolic.ml
+++ b/libASL/symbolic.ml
@@ -990,6 +990,10 @@ let prims_impure () =
     FIdent("AtomicEnd",0);
     FIdent("AArch64.MemTag.read",0);
     FIdent("AArch64.MemTag.set",0);
+    FIdent("SetTagCheckedInstruction",0);
+    FIdent("SpeculativeStoreBypassBarrierToPA",0);
+    FIdent("SpeculationBarrier",0);
+    FIdent("SpeculativeStoreBypassBarrierToVA",0);
   ]
 
 (** Test if an expression is only over constants, variables and pure operations. Does not

--- a/libASL/symbolic_lifter.ml
+++ b/libASL/symbolic_lifter.ml
@@ -135,9 +135,9 @@ module RemoveUnsupported = struct
       | Stmt_Dep_ImpDef (_, loc)
       | Stmt_See (_, loc)
       | Stmt_Throw (_, loc)
-      | Stmt_DecodeExecute (_, _, loc) -> ChangeTo (assert_false loc)
-
-      | _ -> failwith @@ "Unknown stmt: " ^ (pp_stmt e))
+      | Stmt_DecodeExecute (_, _, loc)
+      | Stmt_Try (_, _, _, _, loc)
+      | Stmt_Repeat (_, _, loc) -> ChangeTo (assert_false loc))
   end
 
   let run unsupported env body =

--- a/libASL/symbolic_lifter.ml
+++ b/libASL/symbolic_lifter.ml
@@ -152,13 +152,10 @@ let unsupported f = IdentSet.mem f unsupported_set
 
 let get_inlining_frontier =
   (* Collect all functions dis will not inline *)
-  let l1 = IdentSet.of_list (List.map (fun (f,i) -> FIdent (f,i)) Dis.no_inline) in
-  let l2 = IdentSet.of_list (List.map (fun (f,i) -> FIdent (f,i)) (Dis.no_inline_pure ())) in
-  (* Collect all prims *)
-  let l3 = IdentSet.of_list (List.map (fun f -> FIdent (f,0)) Value.prims_pure) in
-  let l4 = IdentSet.of_list (List.map (fun f -> FIdent (f,0)) Value.prims_impure) in
+  let l1 = IdentSet.of_list (Symbolic.prims_impure ()) in
+  let l2 = IdentSet.of_list (Symbolic.prims_pure ()) in
   (* Union with the unsupported function set *)
-  IdentSet.union l1 (IdentSet.union l2 (IdentSet.union l3 (IdentSet.union l4 unsupported_set)))
+  IdentSet.union l1 l2
 
 (* Count individual stmts present after disassembly *)
 let rec stmt_count s =

--- a/libASL/transforms.ml
+++ b/libASL/transforms.ml
@@ -3185,8 +3185,6 @@ module LoopClassify = struct
     | "mul_int", 0, [], [Index (base,mul);Constant offset]
     | "mul_int", 0, [], [Constant offset;Index (base,mul)] ->
         Index (mul_int base offset, mul_int mul offset)
-    | "sdiv_int", 0, [], [Index(base,mul);Constant div] ->
-        Index (div_int base div, div_int mul div)
 
     (* Supported operations over BVIndex TODO: These don't really handle overflow properly *)
     | "cvt_bits_sint", 0, [Constant w], [BVIndex(b,m,_)] ->

--- a/libASL/utils.ml
+++ b/libASL/utils.ml
@@ -37,14 +37,14 @@ let to_string (d: PPrint.document): string =
 let rec take (n: int) (xs: 'a list) =
     match xs with
     | _ when n < 0 -> failwith "take: negative"
-    | [] when n = 0 -> []
+    | l when n = 0 -> []
     | [] -> failwith "take: list too short"
     | x::rest -> x :: take (n-1) rest
 
 let rec drop (n: int) (xs: 'a list) =
     match xs with
     | _ when n < 0 -> failwith "drop: negative"
-    | [] when n = 0 -> []
+    | l when n = 0 -> l
     | [] -> failwith "drop: list too short"
     | _::rest -> drop (n-1) rest
 

--- a/libASL/value.ml
+++ b/libASL/value.ml
@@ -387,7 +387,7 @@ let eval_prim (f: string) (tvs: value list) (vs: value list): value option =
 let prims_pure = [
     "eq_enum"; "eq_enum"; "ne_enum"; "ne_enum"; "eq_bool"; "ne_bool"; "equiv_bool"; "not_bool"; "eq_int"; "ne_int"; "le_int";
     "lt_int"; "ge_int"; "gt_int"; "is_pow2_int"; "neg_int"; "add_int"; "sub_int"; "shl_int"; "shr_int"; "mul_int"; "zdiv_int";
-    "zrem_int"; "sdiv_int"; "fdiv_int"; "frem_int"; "mod_pow2_int"; "align_int"; "pow2_int"; "pow_int_int"; "cvt_int_real"; "eq_real";
+    "zrem_int"; "fdiv_int"; "frem_int"; "mod_pow2_int"; "align_int"; "pow2_int"; "pow_int_int"; "cvt_int_real"; "eq_real";
     "ne_real"; "le_real"; "lt_real"; "ge_real"; "gt_real"; "add_real"; "neg_real"; "sub_real"; "mul_real"; "divide_real";
     "pow2_real"; "round_tozero_real"; "round_down_real"; "round_up_real"; "sqrt_real"; "cvt_int_bits"; "cvt_bits_sint";
     "cvt_bits_uint"; "in_mask"; "notin_mask"; "eq_bits"; "ne_bits"; "add_bits"; "sub_bits"; "mul_bits"; "and_bits"; "or_bits";

--- a/offlineASL-cpp/subprojects/aslp-lifter-llvm/include/aslp/llvm_interface.hpp
+++ b/offlineASL-cpp/subprojects/aslp-lifter-llvm/include/aslp/llvm_interface.hpp
@@ -340,6 +340,7 @@ public:
     return builder->CreateLoad(intty(int_expr(width)), ptr);
   }
   void f_gen_AArch64_MemTag_set(rt_expr address, rt_expr acctype, rt_expr value) override { assert(0); }
+  rt_expr f_gen_AArch64_MemTag_read(rt_expr address, rt_expr acctype) override { assert(0); }
 
   void f_AtomicStart() override { assert(0); }
   void f_AtomicEnd() override { assert(0); }

--- a/offlineASL-cpp/subprojects/aslp-lifter/include/aslp/interface.hpp
+++ b/offlineASL-cpp/subprojects/aslp-lifter/include/aslp/interface.hpp
@@ -111,6 +111,7 @@ public:
                                  rt_expr acctype) = 0;
   virtual void f_gen_AArch64_MemTag_set(rt_expr address, rt_expr acctype,
                                         rt_expr value) = 0;
+  virtual rt_expr f_gen_AArch64_MemTag_read(rt_expr address, rt_expr acctype) = 0;
 
   virtual void f_AtomicStart() = 0;
   virtual void f_AtomicEnd() = 0;

--- a/offlineASL-scala/lifter/src/interface.scala
+++ b/offlineASL-scala/lifter/src/interface.scala
@@ -95,6 +95,7 @@ trait LiftState[RTSym, RTLabel, BV <: RTSym] {
   def f_gen_slt_bits(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym
   def f_gen_sub_bits(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym
   def f_gen_AArch64_MemTag_set(arg0: RTSym, arg1: RTSym, arg2: RTSym): RTSym
+  def f_gen_AArch64_MemTag_read(arg0: RTSym, arg1: RTSym): RTSym
   def f_gen_Mem_read(targ0: BigInt, arg0: RTSym, arg1: RTSym, arg2: RTSym): RTSym
   def f_gen_slice(e: RTSym, lo: BigInt, wd: BigInt): RTSym
   def f_gen_replicate_bits(targ0: BigInt, targ1: BigInt, arg0: RTSym, arg1: BV): RTSym

--- a/offlineASL-scala/main/src/NoneLifter.scala
+++ b/offlineASL-scala/main/src/NoneLifter.scala
@@ -106,6 +106,7 @@ class NotImplementedLifter extends LiftState[RExpr, String, BitVec] {
   def f_gen_slt_bits(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
   def f_gen_sub_bits(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
   def f_gen_AArch64_MemTag_set(arg0: RTSym, arg1: RTSym, arg2: RTSym): RTSym = throw NotImplementedError()
+  def f_gen_AArch64_MemTag_read(arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
   def f_gen_Mem_read(targ0: BigInt, arg0: RTSym, arg1: RTSym, arg2: RTSym): RTSym = throw NotImplementedError()
   def f_gen_slice(e: RTSym, lo: BigInt, wd: BigInt): RTSym = throw NotImplementedError()
   def f_gen_replicate_bits(targ0: BigInt, targ1: BigInt, arg0: RTSym, arg1: BV): RTSym = throw NotImplementedError()

--- a/offlineASL/offline_utils.ml
+++ b/offlineASL/offline_utils.ml
@@ -191,6 +191,8 @@ let f_AtomicEnd () =
   push_stmt (Stmt_TCall (FIdent ("AtomicEnd", 0), [], [], Unknown))
 let f_gen_AArch64_MemTag_set x y z: unit =
   failwith "MemTag_set unsupported"
+let f_gen_AArch64_MemTag_read x y =
+  failwith "MemTag_read unsupported"
 
 (* Prim bool ops *)
 let f_gen_and_bool e1 e2 =


### PR DESCRIPTION
* ~~Enable SVE in the default lifter config~~
* Fix the list `take` and `drop` utilities
* Common pure/impure primitive operations into a single config
* Stop dead code removal from removing impure operations
* Remove incorrect primitive `sdiv_int`
* Limit CSE to pure expressions over constant variables

EDIT: SVE opens a whole can of worms for the offline lifters. Will need to handle this later.