### PR TITLE
aslp-cpp: exit from forked server subprocess

### DIFF
--- a/aslp-cpp/include/aslp-cpp/aslp-cpp.hpp
+++ b/aslp-cpp/include/aslp-cpp/aslp-cpp.hpp
@@ -31,8 +31,8 @@ public:
 class aslp_client
 {
 private:
-  const std::string server_addr;
   pid_t server_pid;
+  const std::string server_addr;
   int server_port;
   void shutdown();
 
@@ -47,8 +47,8 @@ public:
    */
   aslp_client(pid_t pid, std::string addr, int port)
       : server_pid(pid)
-      , server_port(port)
       , server_addr(std::move(addr))
+      , server_port(port)
   {
   }
 

--- a/aslp-cpp/source/aslp-cpp.cpp
+++ b/aslp-cpp/source/aslp-cpp.cpp
@@ -125,8 +125,9 @@ auto aslp_client::start(const std::string& addr, int server_port)
     auto command = std::format(
         "opam exec -- aslp-server --host {} --port {}", addr, server_port);
     std::cerr << command << std::endl;
-    std::system(command.c_str());
-    std::cerr << "Child process exited." << std::endl;
+    int retcode = std::system(command.c_str());
+    std::cerr << "Child process exited with code: " << retcode << std::endl;
+    std::exit(retcode);
     return {nullptr};
   }
 


### PR DESCRIPTION
the forked subprocess should not return to its caller.

also fixes an "unused return value" wawrning from std::system.