### PR TITLE
Add cache to http server and mutlithread with eio

### DIFF
--- a/aslp-cpp/source/aslp-cpp.cpp
+++ b/aslp-cpp/source/aslp-cpp.cpp
@@ -8,7 +8,6 @@
 #include <iostream>
 #include <memory>
 #include <optional>
-#include <ranges>
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
@@ -113,14 +112,13 @@ auto get_proc_children_transitive(pid_t proc) -> std::vector<pid_t>
   return get_proc_children(pids, proc, /*recursive=*/true);
 }
 
-auto aslp_client::start(const std::string& addr, int server_port)
-    -> std::unique_ptr<aslp_client>
+auto aslp_client::start(const std::string& addr,
+                        int server_port) -> std::unique_ptr<aslp_client>
 {
   auto pid = fork();
 
   if (pid != 0) {
-    return std::make_unique<aslp_client> (
-        pid, addr, server_port);
+    return std::make_unique<aslp_client>(pid, addr, server_port);
   } else {
     auto command = std::format(
         "opam exec -- aslp-server --host {} --port {}", addr, server_port);
@@ -138,19 +136,15 @@ void aslp_connection::wait_active()
 {
   auto req = client->Get("/");
 
-  std::cout << "Waiting for server to start.";
   while (req.error() != httplib::Error::Success) {
-    std::cout << "." << std::flush;
     std::this_thread::sleep_for(std::chrono::milliseconds(1000));
     req = client->Get("/");
   }
-  std::cout << "\n";
 }
 
 aslp_opcode_result_t aslp_connection::get_opcode(uint32_t opcode)
 {
   auto codestr = std::format("{:#x}", opcode);
-  std::cout << codestr << "\n";
   auto params = httplib::Params({{"opcode", codestr}});
   for (const auto& pair : extra_params) {
     params.insert(pair);

--- a/aslp-cpp/test/source/aslp-cpp_test.cpp
+++ b/aslp-cpp/test/source/aslp-cpp_test.cpp
@@ -1,21 +1,57 @@
+#include <iostream>
+#include <memory>
+#include <random>
 #include <string>
+#include <chrono>
 
 #include "aslp-cpp/aslp-cpp.hpp"
-#include <iostream> 
+
+class opgen
+{
+  std::unique_ptr<std::mt19937> rng;
+  std::unique_ptr<std::uniform_int_distribution<std::mt19937::result_type>>
+      dist;
+
+public:
+  opgen()
+  {
+    rng = std::make_unique<std::mt19937>(1234);
+    dist = std::make_unique<
+        std::uniform_int_distribution<std::mt19937::result_type>>(0,
+                                                                  UINT32_MAX);
+  }
+
+  uint32_t get() { return (*dist)(*rng); }
+};
+
 
 auto main() -> int
 {
-  auto s = aslp_client::start();
+  auto s = aslp_connection("127.0.0.1", 8000);
+  auto gen = opgen();
 
-  try {
+  std::chrono::time_point begin = std::chrono::high_resolution_clock::now();
+
+  auto add_mask = 0b00010001111111111111111111111111 ;
+  auto add_set = 0b01000000000000000000000000000000 ;
+
+  for (int i = 0; i < 50000; i++) {
     std::string c;
-    std::tie(std::ignore, c) = s->get_opcode(0xFD430091);
-    std::cout << c << "\n";
-  } catch (std::runtime_error &e) {
-    std::cout << " error " << e.what() << "\n";
-    return 1;
-  } 
+    auto op = gen.get();
 
+    if ((i % 1000) == 0) {
+      std::cout << "Did " << i << "\n";
+    }
+
+    try {
+      std::string c;
+      std::tie(std::ignore, c) = s.get_opcode(op);
+
+    } catch (std::runtime_error& e) {
+    }
+  }
+  auto end = std::chrono::high_resolution_clock::now();
+  std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(end-begin).count() << " ms" << std::endl;
 
   return 0;
 }

--- a/aslp_server/aslp_server.opam
+++ b/aslp_server/aslp_server.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/UQ-PAC/aslp"
 doc: "https://github.com/UQ-PAC/aslp"
 bug-reports: "https://github.com/UQ-PAC/aslp/issues"
 depends: [
-  "ocaml" {>= "5.1"}
+  "ocaml" {>= "5.0"}
   "dune" {>= "2.8"}
   "eio"
   "cohttp-eio"

--- a/aslp_server/aslp_server.opam
+++ b/aslp_server/aslp_server.opam
@@ -15,7 +15,6 @@ depends: [
   "cohttp-eio"
   "yojson"
   "asli"
-  "janestreet_lru_cache"
   "odoc" {with-doc}
 ]
 build: [

--- a/aslp_server/aslp_server.opam
+++ b/aslp_server/aslp_server.opam
@@ -9,11 +9,13 @@ homepage: "https://github.com/UQ-PAC/aslp"
 doc: "https://github.com/UQ-PAC/aslp"
 bug-reports: "https://github.com/UQ-PAC/aslp/issues"
 depends: [
-  "ocaml"
+  "ocaml" {>= "5.1"}
   "dune" {>= "2.8"}
-  "cohttp-lwt-unix"
+  "eio"
+  "cohttp-eio"
   "yojson"
   "asli"
+  "janestreet_lru_cache"
   "odoc" {with-doc}
 ]
 build: [

--- a/aslp_server/bin/dune
+++ b/aslp_server/bin/dune
@@ -4,6 +4,6 @@
  (name main)
  (modules main)
  (libraries asli.libASL yojson cohttp-eio pprint
-            core eio eio_main eio.unix janestreet_lru_cache
+            core eio eio_main eio.unix
             ))
 

--- a/aslp_server/bin/dune
+++ b/aslp_server/bin/dune
@@ -3,5 +3,7 @@
  (modes exe byte)
  (name main)
  (modules main)
- (libraries asli.libASL lwt.unix yojson cohttp-lwt cohttp-lwt-unix pprint))
+ (libraries asli.libASL yojson cohttp-eio pprint
+            core eio eio_main eio.unix janestreet_lru_cache
+            ))
 

--- a/aslp_server/bin/main.ml
+++ b/aslp_server/bin/main.ml
@@ -1,91 +1,154 @@
 open LibASL
-
 open Cohttp
-open Cohttp_lwt_unix
+open Cohttp_eio
 open List
 open Asl_ast
-open Lwt
 
+let persistent_env = Option.get (Arm_env.aarch64_evaluation_environment ())
+let count = Atomic.make 0
 
-let persistent_env = lazy (Option.get (Arm_env.aarch64_evaluation_environment ()))
+let eval_instr (opcode : string) : string * string =
+  let pp_raw stmt : string =
+    Utils.to_string (Asl_parser_pp.pp_raw_stmt stmt) |> String.trim
+  in
+  let _address = None in
 
-let eval_instr (opcode: string) : string * string =
-    let pp_raw stmt : string = Utils.to_string (Asl_parser_pp.pp_raw_stmt stmt) |> String.trim  in
-    let _address = None in
+  let env' = persistent_env in
+  let lenv = Dis.build_env env' in
+  let decoder = Eval.Env.getDecoder env' (Ident "A64") in
+  let enc, stmts =
+    Dis.dis_decode_entry_with_inst env' lenv decoder (Z.of_string opcode)
+  in
 
-    let env' = Lazy.force persistent_env in
-    let lenv = Dis.build_env env' in
-    let decoder = Eval.Env.getDecoder env' (Ident "A64") in
-    let (enc,stmts) = Dis.dis_decode_entry_with_inst env' lenv decoder (Z.of_string opcode) in
+  let stmts' = List.map pp_raw stmts in
+  (enc, String.concat "\n" stmts')
 
-    let stmts'   = List.map pp_raw stmts in
-    enc, String.concat "\n" stmts'
-
-let get_reply (jsonin: string) : Cohttp.Code.status_code * string =
-  (*let json  = Yojson.Safe.from_string jsonin in *)
+let get_reply (jsonin : string) : Cohttp.Code.status_code * string =
   let make_reply code tail =
-    (code, Yojson.Safe.to_string (`Assoc (["instruction", `String jsonin] @ tail))) in
-  Printf.printf "Disassembling '%s'\n" jsonin;
-  flush stdout;
-  match (eval_instr jsonin) with
-  | exception e -> make_reply `Internal_server_error ["error", `String (Printexc.to_string e)]
-  | enc, x -> make_reply `OK [ "encoding", `String enc; "semantics", `String x; ]
-
+    ( code,
+      Yojson.Safe.to_string
+        (`Assoc ([ ("instruction", `String jsonin) ] @ tail)) )
+  in
+  match eval_instr jsonin with
+  | exception e ->
+      make_reply `Internal_server_error
+        [ ("error", `String (Printexc.to_string e)) ]
+  | enc, x ->
+      make_reply `OK [ ("encoding", `String enc); ("semantics", `String x) ]
 
 let unsupp_method_resp : Cohttp.Code.status_code * string =
-  (`Method_not_allowed, Yojson.Safe.to_string (`Assoc [("error", `String "unsupported method.")]))
+  ( `Method_not_allowed,
+    Yojson.Safe.to_string (`Assoc [ ("error", `String "unsupported method.") ])
+  )
 
 let missing_param : Cohttp.Code.status_code * string =
-  (`Bad_request, Yojson.Safe.to_string (`Assoc [("error", `String "missing opcode param.")]))
+  ( `Bad_request,
+    Yojson.Safe.to_string
+      (`Assoc [ ("error", `String "missing opcode param.") ]) )
 
 let try_set_flags xs : (unit, Cohttp.Code.status_code * string) Result.t =
-  match (List.iter Flags.set_flag xs) with
-  | exception (Arg.Bad _ as e) -> Result.error (`Bad_request, Yojson.Safe.to_string (`Assoc [("error", `String (Printexc.to_string e))]))
+  match List.iter Flags.set_flag xs with
+  | exception (Arg.Bad _ as e) ->
+      Result.error
+        ( `Bad_request,
+          Yojson.Safe.to_string
+            (`Assoc [ ("error", `String (Printexc.to_string e)) ]) )
   | _ -> Result.ok ()
 
-let get_resp (opcode: string) : Cohttp.Code.status_code * string =
-    get_reply opcode
+let get_resp (opcode : string) : Cohttp.Code.status_code * string =
+  get_reply opcode
 
-let server addr port =
+let mutex = Eio.Mutex.create ()
+
+type 'a work = Decode of (string * ('a, exn) result Eio.Promise.u)
+
+let has_work = Eio.Condition.create ()
+
+module DisCache = Lru_cache.Make (Core.String)
+
+let cache : (Code.status_code * string) DisCache.t =
+  DisCache.create ~max_size:5000 ()
+
+let cache_mutex = Eio.Mutex.create ()
+
+let submit_req_executor_pool pool opcode =
+  (* CACHE IS NOT THREADSAFE, only call this from one domain *)
+  let default () =
+    Atomic.incr count;
+    Eio.Executor_pool.submit_exn pool ~weight:0.001 (fun () -> get_resp opcode)
+  in
+  DisCache.find_or_add cache opcode ~default
+
+let server socket addr port get_resp =
   Printf.printf "Started aslp-server at http://%s:%d\n" addr port;
   flush stdout;
 
   let oldflags = Flags.get_flags () in
 
-  let callback _conn req body =
+  let callback _conn req (body : Server.body) =
     let uri = req |> Request.uri in
     let _meth = req |> Request.meth |> Code.string_of_method in
     let _headers = req |> Request.headers |> Header.to_string in
-    let body' = body |> Cohttp_lwt.Body.to_string in
 
     Flags.set_flags oldflags;
 
-    let resp' = 
-      match (Option.map try_set_flags (Uri.get_query_param' uri "flags")) with
-      | Some (Error xs) -> Lwt.return xs
-      | Some (Ok ()) | None ->
-        match (Request.meth req, Uri.get_query_param uri "opcode") with
-        | `POST, _ -> body' >|= get_resp
-        | `GET, Some param -> Lwt.return (get_resp param)
-        | `GET, None -> Lwt.return missing_param
-        |  _ -> Lwt.return unsupp_method_resp
+    let code, body =
+      match Option.map try_set_flags (Uri.get_query_param' uri "flags") with
+      | Some (Error xs) -> xs
+      | Some (Ok ()) | None -> (
+          match (Request.meth req, Uri.get_query_param uri "opcode") with
+          | `POST, _ ->
+              let body' : string = Eio.Flow.read_all body in
+              get_resp body'
+          | `GET, Some param -> get_resp param
+          | `GET, None -> missing_param
+          | _ -> unsupp_method_resp)
     in
-    resp' >>= fun (code, body) -> Server.respond_string ~status:code ~body ()
+    Server.respond_string ~status:code ~body ()
   in
-  Server.create ~mode:(`TCP (`Port port)) (Server.make ~callback ())
+  Server.run
+    ~mode:(`TCP (`Port port))
+    socket (Server.make ~callback ())
+    ~on_error:(Eio.traceln "Error handling connection: %a" Fmt.exn)
 
 let port_opt : int ref = ref 8000
 let addr_opt : string ref = ref "127.0.0.1"
+let threads_opt : int ref = ref 2
 
 let speclist =
   [
-    ("--host", Arg.Set_string addr_opt, "Server address (default loopback)");
+    ("--host", Arg.Set_string addr_opt, "Server ip address (default 127.0.0.1)");
     ("--port", Arg.Set_int port_opt, "Server port (default 8000)");
+    ("--threads", Arg.Set_int threads_opt, "Number of lifter worker threads");
   ]
 
-let () = Arg.parse speclist ignore "usage: aslp-server --host HOSTNAME --port PORT"
+let rec periodic t () =
+  Eio.Time.sleep t 5.0;
+  Eio.traceln "Cache hit rate: %f handled: %d" (DisCache.hit_rate cache)
+    (Atomic.get count);
+  periodic t ()
 
 let () =
-  let _address = Unix.(ADDR_INET (inet_addr_of_string !addr_opt, !port_opt)) in
-  Lwt_main.run (server !addr_opt !port_opt)
-
+  Arg.parse speclist ignore "usage: aslp-server --host HOSTNAME --port PORT";
+  let main env =
+    let unix_addr = Unix.inet_addr_of_string !addr_opt in
+    let e = Eio_unix.Net.Ipaddr.of_unix unix_addr in
+    let addr = `Tcp (e, !port_opt) in
+    let work sw =
+      Eio.Fiber.fork ~sw (periodic env#clock);
+      let pool =
+        Eio.Executor_pool.create ~sw env#domain_mgr ~domain_count:!threads_opt
+      in
+      let decode opcode = submit_req_executor_pool pool opcode in
+      let socket =
+        Eio.Net.listen ~sw ~backlog:5 ~reuse_addr:true env#net addr
+      in
+      let fd = Eio_unix.Net.fd socket in
+      Eio_unix.Fd.use fd
+        (fun fd -> Unix.setsockopt fd Unix.TCP_NODELAY true)
+        ~if_closed:(fun () -> ());
+      server socket !addr_opt !port_opt decode
+    in
+    Eio.Switch.run work
+  in
+  Eio_main.run main

--- a/aslp_server/dune-project
+++ b/aslp_server/dune-project
@@ -18,10 +18,14 @@
  (name aslp_server)
  (synopsis "REST server for ASLp")
  (description "")
- (depends ocaml dune
-    "cohttp-lwt-unix"
+ (depends 
+   ("ocaml" (>= "5.0"))
+     dune
+    "eio"
+    "cohttp-eio"
     "yojson"
     "asli"
+    janestreet_lru_cache
  )
  )
 

--- a/aslp_server/dune-project
+++ b/aslp_server/dune-project
@@ -25,7 +25,6 @@
     "cohttp-eio"
     "yojson"
     "asli"
-    janestreet_lru_cache
  )
  )
 

--- a/aslp_server/stress.lua
+++ b/aslp_server/stress.lua
@@ -1,0 +1,20 @@
+
+-- example script that demonstrates use of setup() to pass
+-- a random server address to each thread
+
+
+function setup(thread)
+end
+
+function init(args)
+   local msg = "thread addr: %s"
+   print(msg:format(wrk.thread.addr))
+end
+
+request = function() 
+  wrk.headers["Connection"] = "Keep-Alive"
+  param_num = math.random(0,4294967295 )
+  param_value = string.format("0x%x" , param_num)
+  path = "/?opcode=" .. param_value
+  return wrk.format("GET", path)
+end

--- a/aslp_server/stress.sh
+++ b/aslp_server/stress.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+dune exec aslp_server --profile=release -- --threads 4 & 
+sleep 5
+wrk2 -t 8 -c64 -d 30s -s stress.lua -R10000 --latency http://localhost:8000
+dune exec aslp_server --profile=release -- --killserver


### PR DESCRIPTION
This substantially improves the throughput of the server, testing with random opcodes gives around 9000 opcodes / sec. 

`$ wrk2 -t 8 -c64 -d 30s -s stress.lua -R10000 --latency http://localhost:8000`

```
#[Mean    =     1150.503, StdDeviation   =     1521.297]
#[Max     =    11919.360, Total count    =       190688]
#[Buckets =           27, SubBuckets     =         2048]
----------------------------------------------------------
  284353 requests in 30.04s, 104.75MB read
  Socket errors: connect 0, read 0, write 0, timeout 2
  Non-2xx or 3xx responses: 193219
Requests/sec:   9465.37
Transfer/sec:      3.49MB
```


![image](https://github.com/user-attachments/assets/e1f8b6e4-bffa-41c5-877d-efb8e883d4a1)

We can see in these tests the in-memory cache has little effect as it is always cold (and the test opcodes are uniformly random, and there are far more of them than the size of the cache). For real programs the cache hit rate should be higher. The 'varnishcachehot' and 'varnishcachecold' are tested by putting the varnish http cache in front of the server, these in the hot case it has pre-cached all the opcodes, and in the cold cache it has just been restarted. We can probably get a nix wrapper to do this?

testing with varnish: 

```
nix-shell -p varnish wrk2
mkdir ~/varnish
varnishd   -b localhost:8000 -a localhost:8001 -n ~/varnish
cd ../aslp/aslp_server
wrk2 -t 64 -c64 -d 100s -s stress.lua -R10000 --latency http://localhost:8001
```


Before these changes we had:

```
#[Mean    =    17361.798, StdDeviation   =     4917.355]
#[Max     =    27901.952, Total count    =        23948]
#[Buckets =           27, SubBuckets     =         2048]
----------------------------------------------------------
  33878 requests in 30.00s, 11.59MB read
  Socket errors: connect 0, read 0, write 0, timeout 53
  Non-2xx or 3xx responses: 23437
Requests/sec:   1129.21
```

I think its possibly worth separating the server and http client into a separate repo. 

I also tested with an lru cache on the cpp side and it didn't have a positive impact, I suspect an LRU cache is not going to be effective with random input. 

---

Parallelism strategy

We have 1 request handler thread (which the (not threadsafe) in-memory cache lives in) and multiple lifter threads which accept work through `Eio.ExecutorPool`. 

Basic benchmarks show that adding threads to the request handler doesn't improve performance as we are significantly bound by the lifting side. 