### PR TITLE
Init vector state in coverage tester

### DIFF
--- a/bin/asli.ml
+++ b/bin/asli.ml
@@ -74,8 +74,7 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
     | [":init"; "globals"] ->
         Eval.initializeGlobals cpu.env;
     | [":init"; "regs"] ->
-        let vals = (List.init 64 (fun _ -> Z.of_int64 (Random.int64 Int64.max_int))) in
-        Eval.initializeRegistersAndMemory cpu.env vals;
+        Eval.randomRegistersAndMemory cpu.env
     | ":enumerate" :: iset :: tail ->
         let (start,stop,fname) = (match tail with
         | [start;stop;fname] -> (int_of_string start, int_of_string stop, fname)
@@ -110,8 +109,7 @@ let rec process_command (tcenv: TC.Env.t) (cpu: Cpu.cpu) (fname: string) (input0
                 (* Set up our environments *)
                 let initEnv = Eval.Env.copy cpu.env in
                 (* Obtain and set random initial values for _R registers. *)
-                let vals = (List.init 64 (fun _ -> Z.of_int64 (Random.int64 Int64.max_int))) in
-                Eval.initializeRegistersAndMemory initEnv vals;
+                Eval.randomRegistersAndMemory initEnv;
                 (* Replace remaining VUninitialized with default zero values. *)
                 Eval.initializeGlobals initEnv;
 

--- a/bin/offline_coverage.ml
+++ b/bin/offline_coverage.ml
@@ -22,8 +22,7 @@ let op_test_opcode (env: Env.t) (iset: string) (op: int): Env.t opresult =
 
   let initenv = Env.copy env in
   Random.self_init ();
-  let vals = (List.init 64 (fun _ -> Z.of_int64 (Random.int64 Int64.max_int))) in
-  Eval.initializeRegistersAndMemory initenv vals;
+  Eval.randomRegistersAndMemory initenv;
   Eval.initializeGlobals initenv;
 
   let initenv = Env.freeze initenv in

--- a/libASL/offline_opt.ml
+++ b/libASL/offline_opt.ml
@@ -522,9 +522,13 @@ module RtCopyProp = struct
     | Some (Defined ids) -> (st, IdentSet.union i ids)
     | _ -> (st, i)
 
+  let impure_ident = Ident "CopyProp_impure"
+
   let write_var v (st,i) =
-    let st = if has_context st then (set_var v Essential st) else st  in
       (* cannot copy-prop exprs dependent on a run-time branch*)
+    let st = if has_context st then (set_var v Essential st) else st  in
+      (* cannot copy-prop impure exprs *)
+    let st = if IdentSet.mem impure_ident i then (set_var v Essential st) else st  in
     let st = clobber_var v st in
     let (st,i) = match get_var v st with
     | Some (Declared) -> (set_var v (Defined i) st, i)
@@ -534,8 +538,6 @@ module RtCopyProp = struct
       | None -> (st, i)
   in  (st,i)
 
-
-  let impure_ident = Ident "CopyProp_impure"
 
   let read_vars (vs: IdentSet.t) (st: state): state =
     let read_set s st = IdentSet.fold read_var s (st,IdentSet.empty) in

--- a/libASL/primops.ml
+++ b/libASL/primops.ml
@@ -104,7 +104,9 @@ let prim_round_up_real     (x: real): bigint =
         Z.add Z.one (Q.to_bigint x)
     end
 
-let prim_sqrt_real         (x: real): real = failwith "prim_sqrt_real"
+(* Can't necessarily represent this as a rational. *)
+let prim_sqrt_real         (x: real): real =
+    Q.make (Z.sqrt (Q.num x)) (Z.sqrt (Q.den x))
 
 
 (****************************************************************)
@@ -213,6 +215,16 @@ let prim_insert (x: bitvector) (i: bigint) (w: bigint) (y: bitvector): bitvector
     let y' = Z.shift_left (z_extract y.v 0 w') i' in
     mkBits x.n (Z.logor (Z.logand nmsk x.v) (Z.logand msk y'))
 
+let prim_insert_int (x: Z.t) (i: bigint) (w: bigint) (y: bitvector): Z.t =
+    let i' = Z.to_int i in
+    let w' = Z.to_int w in
+    assert (0 <= i');
+    assert (0 <= w');
+    assert (w' = y.n);
+    let msk = (Z.sub (Z.shift_left Z.one (i'+w')) (Z.shift_left Z.one i')) in
+    let nmsk = Z.lognot msk in
+    let y' = Z.shift_left (z_extract y.v 0 w') i' in
+    (Z.logor (Z.logand nmsk x) (Z.logand msk y'))
 
 (****************************************************************)
 (** {2 Mask primops}                                            *)

--- a/libASL/scala_backend.ml
+++ b/libASL/scala_backend.ml
@@ -52,6 +52,7 @@ module StringSet = Set.Make(String)
         "f_gen_FPRecipEstimate"; "f_gen_FPRecipStepFused"; "f_gen_FPRecpX";
         "f_gen_FPRoundInt"; "f_gen_FPRoundIntN"; "f_gen_FPSqrt"; "f_gen_FPSub";
         "f_gen_FPToFixed"; "f_gen_FPToFixedJS_impl"; "f_gen_FixedToFP";
+        "f_gen_FPRSqrtEstimate"; "f_gen_UnsignedRSqrtEstimate";
         "f_gen_bit_lit"; "f_gen_bool_lit"; "f_gen_branch"; "f_cvt_bits_uint";
         "f_gen_cvt_bits_uint"; "f_gen_cvt_bool_bv"; "f_gen_eor_bits";
         "f_gen_eq_bits"; "f_gen_eq_enum"; "f_gen_int_lit"; "f_gen_store";

--- a/libASL/symbolic.ml
+++ b/libASL/symbolic.ml
@@ -984,6 +984,8 @@ let prims_impure () =
     FIdent("BFAdd",0);
     FIdent("BFMul",0);
     FIdent("FPRecipEstimate",0);
+    FIdent("UnsignedRSqrtEstimate",0);
+    FIdent("FPRSqrtEstimate",0);
     FIdent("Mem.read",0);
     FIdent("Mem.set",0);
     FIdent("AtomicStart",0);

--- a/libASL/testing.ml
+++ b/libASL/testing.ml
@@ -404,8 +404,7 @@ let op_test_opcode (env: Env.t) (iset: string) (op: int): Env.t opresult =
 
   let initenv = Env.copy env in
   Random.self_init ();
-  let vals = (List.init 64 (fun _ -> Z.of_int64 (Random.int64 Int64.max_int))) in
-  Eval.initializeRegistersAndMemory initenv vals;
+  Eval.randomRegistersAndMemory initenv;
   Eval.initializeGlobals initenv;
 
   let initenv = Env.freeze initenv in

--- a/libASL/value.ml
+++ b/libASL/value.ml
@@ -307,7 +307,7 @@ let eval_prim (f: string) (tvs: value list) (vs: value list): value option =
     | ("round_tozero_real", [      ], [VReal x             ])     -> Some (VInt    (prim_round_tozero_real x))
     | ("round_down_real",   [      ], [VReal x             ])     -> Some (VInt    (prim_round_down_real x))
     | ("round_up_real",     [      ], [VReal x             ])     -> Some (VInt    (prim_round_up_real x))
-    | ("sqrt_real",         [      ], [VReal x; VReal y    ])     -> Some (VReal   (prim_sqrt_real x))
+    | ("sqrt_real",         [      ], [VReal x             ])     -> Some (VReal   (prim_sqrt_real x))
     | ("cvt_int_bits",      [_     ], [VInt  x; VInt  n    ])     -> Some (VBits   (prim_cvt_int_bits n x))
     | ("cvt_bits_sint",     [VInt n], [VBits x             ])     -> Some (VInt    (prim_cvt_bits_sint x))
     | ("cvt_bits_uint",     [VInt n], [VBits x             ])     -> Some (VInt    (prim_cvt_bits_uint x))
@@ -424,6 +424,11 @@ let insert_bits (loc: AST.l) (x: value) (i: value) (w: value) (y: value): value 
 
 let insert_bits' (loc: AST.l) (x: value) (i: int) (w: int) (y: value): value =
     VBits (prim_insert (to_bits loc x) (Z.of_int i) (Z.of_int w) (to_bits loc y))
+
+let insert_bits'' (loc: AST.l) (x: value) (i: value) (w: value) (y: value): value =
+    (match x with
+    | VInt(x')  -> VInt (prim_insert_int x' (to_integer loc i) (to_integer loc w) (to_bits loc y))
+    | _ -> insert_bits loc x i w y)
 
 let rec eval_eq (loc: AST.l) (x: value) (y: value): bool =
     (match (x, y) with

--- a/offlineASL-cpp/subprojects/aslp-lifter-llvm/include/aslp/llvm_interface.hpp
+++ b/offlineASL-cpp/subprojects/aslp-lifter-llvm/include/aslp/llvm_interface.hpp
@@ -489,6 +489,8 @@ public:
   rt_expr f_gen_FPRecpX(rt_expr x, rt_expr fpcr) override { assert(0); }
   rt_expr f_gen_FPSqrt(rt_expr x, rt_expr fpcr) override { assert(0); }
   rt_expr f_gen_FPRecipEstimate(rt_expr x, rt_expr fpcr) override { assert(0); }
+  rt_expr f_gen_UnsignedRSqrtEstimate(rt_expr x) override { assert(0); }
+  rt_expr f_gen_FPRSqrtEstimate(rt_expr x, rt_expr fpcr) override { assert(0); }
   rt_expr f_gen_BFAdd(rt_expr x, rt_expr y) override { assert(0); }
   rt_expr f_gen_BFMul(rt_expr x, rt_expr y) override { assert(0); }
   rt_expr f_gen_FPConvertBF(rt_expr x, rt_expr fpcr, rt_expr rounding) override { assert(0); }

--- a/offlineASL-cpp/subprojects/aslp-lifter/include/aslp/interface.hpp
+++ b/offlineASL-cpp/subprojects/aslp-lifter/include/aslp/interface.hpp
@@ -168,6 +168,8 @@ public:
   virtual rt_expr f_gen_FPRecpX(rt_expr x, rt_expr fpcr) = 0;
   virtual rt_expr f_gen_FPSqrt(rt_expr x, rt_expr fpcr) = 0;
   virtual rt_expr f_gen_FPRecipEstimate(rt_expr x, rt_expr fpcr) = 0;
+  virtual rt_expr f_gen_UnsignedRSqrtEstimate(rt_expr x) = 0;
+  virtual rt_expr f_gen_FPRSqrtEstimate(rt_expr x, rt_expr fpcr) = 0;
   virtual rt_expr f_gen_BFAdd(rt_expr x, rt_expr y) = 0;
   virtual rt_expr f_gen_BFMul(rt_expr x, rt_expr y) = 0;
   virtual rt_expr f_gen_FPConvertBF(rt_expr x, rt_expr fpcr,

--- a/offlineASL-scala/lifter/src/interface.scala
+++ b/offlineASL-scala/lifter/src/interface.scala
@@ -55,6 +55,8 @@ trait LiftState[RTSym, RTLabel, BV <: RTSym] {
   def f_gen_FPMulX(targ0: BigInt, arg0: RTSym, arg1: RTSym, arg2: RTSym): RTSym
   def f_gen_FPRSqrtStepFused(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym
   def f_gen_FPRecipEstimate(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym
+  def f_gen_UnsignedRSqrtEstimate(targ0: BigInt, arg0: RTSym): RTSym 
+  def f_gen_FPRSqrtEstimate(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym
   def f_gen_FPRecipStepFused(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym
   def f_gen_FPRecpX(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym
   def f_gen_FPRoundInt(targ0: BigInt, arg0: RTSym, arg1: RTSym, arg2: RTSym, arg3: RTSym): RTSym

--- a/offlineASL-scala/main/src/NoneLifter.scala
+++ b/offlineASL-scala/main/src/NoneLifter.scala
@@ -66,6 +66,8 @@ class NotImplementedLifter extends LiftState[RExpr, String, BitVec] {
   def f_gen_FPMulX(targ0: BigInt, arg0: RTSym, arg1: RTSym, arg2: RTSym): RTSym = throw NotImplementedError()
   def f_gen_FPRSqrtStepFused(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
   def f_gen_FPRecipEstimate(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
+  def f_gen_UnsignedRSqrtEstimate(targ0: BigInt, arg0: RTSym): RTSym = throw NotImplementedError()
+  def f_gen_FPRSqrtEstimate(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
   def f_gen_FPRecipStepFused(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
   def f_gen_FPRecpX(targ0: BigInt, arg0: RTSym, arg1: RTSym): RTSym = throw NotImplementedError()
   def f_gen_FPRoundInt(targ0: BigInt, arg0: RTSym, arg1: RTSym, arg2: RTSym, arg3: RTSym): RTSym = throw NotImplementedError()

--- a/offlineASL/offline_utils.ml
+++ b/offlineASL/offline_utils.ml
@@ -290,6 +290,10 @@ let f_gen_FPSqrt w x t =
   Expr_TApply (FIdent ("FPSqrt", 0), [expr_of_z w], [x; t])
 let f_gen_FPRecipEstimate w x r =
   Expr_TApply (FIdent ("FPRecipEstimate", 0), [expr_of_z w], [x; r])
+let f_gen_UnsignedRSqrtEstimate w x =
+  Expr_TApply (FIdent ("UnsignedRSqrtEstimate", 0), [expr_of_z w], [x])
+let f_gen_FPRSqrtEstimate w x r =
+  Expr_TApply (FIdent ("FPRSqrtEstimate", 0), [expr_of_z w], [x; r])
 
 let f_gen_BFAdd x y =
   Expr_TApply (FIdent ("BFAdd", 0), [], [x; y])

--- a/tests/test_asl.ml
+++ b/tests/test_asl.ml
@@ -61,8 +61,7 @@ let test_compare env () : unit =
             let initEnv = Eval.Env.copy env in
             (* Obtain and set random initial values for _R registers. *)
             Random.self_init ();
-            let vals = (List.init 64 (fun _ -> Z.of_int64 (Random.int64 Int64.max_int))) in
-            Eval.initializeRegistersAndMemory initEnv vals;
+            Eval.randomRegistersAndMemory initEnv;
             (* Replace remaining VUninitialized with default zero values. *)
             Eval.initializeGlobals initEnv;
 


### PR DESCRIPTION
Sets the vector register array `_Z` to a series of random values. To simplify this change, also adds a call into the state to randomise this array, along with the existing `_R` array. Identifies and fixes three issues as a result of new behaviour:

* `X[slice] = ...` where `X` is an integer was not supported
* Adds `UnsignedRSqrtEstimate` and `FPRSqrtEstimate` to impure prims
* Makes a guess at the implementation of `sqrt_real`
* Offline copy prop could eliminate an impure operation by propagating it into a lift-time branch. Stop it from propagating any impure operation.