### PR TITLE
mark dune.generated files as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,4 @@
 *.t     linguist-vendored
 *.asl   linguist-vendored
 /aslp-cpp/lib/** linguist-vendored
+dune.generated linguist-generated


### PR DESCRIPTION
to hide them from diffs and stats