### PR TITLE
Changes for RISC-V support

### DIFF
--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -478,9 +478,9 @@ end
 class pruneParensClass = object
   inherit nopAslVisitor
   method! vexpr x =
-    match x with
-    | Expr_Parens e -> ChangeTo e
-    | _ -> DoChildren
+    ChangeDoChildrenPost(x, function 
+    | Expr_Parens e -> e
+    | e -> e)
 end
 
 let prune_parens e =

--- a/libASL/asl_utils.ml
+++ b/libASL/asl_utils.ml
@@ -475,6 +475,18 @@ class replaceExprClass (replace: expr -> expr option) = object
         )
 end
 
+class pruneParensClass = object
+  inherit nopAslVisitor
+  method! vexpr x =
+    match x with
+    | Expr_Parens e -> ChangeTo e
+    | _ -> DoChildren
+end
+
+let prune_parens e =
+  let c = new pruneParensClass in
+  visit_expr c e
+
 (****************************************************************)
 (** {2 Resugaring}                                              *)
 (****************************************************************)

--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -1561,22 +1561,26 @@ let build_env (env: Eval.Env.t): env =
     let lenv = LocalEnv.init env in
     let loc = Unknown in
 
-    (* get the pstate, then construct a new pstate where nRW=0, EL=0 & SP=0, then set the pstate *)
-    let (_, pstate) = LocalEnv.getVar loc (Var(0, ("PSTATE"))) lenv in
-    let pstate = (match pstate with
-    | Val(pstate_v) ->
-      let pstate_v = set_access_chain loc pstate_v [Field(Ident("EL"))] (VBits({n=2; v=Z.zero;})) in
-      let pstate_v = set_access_chain loc pstate_v [Field(Ident("SP"))] (VBits({n=1; v=Z.zero;})) in
-      let pstate_v = set_access_chain loc pstate_v [Field(Ident("nRW"))] (VBits({n=1; v=Z.zero;})) in
-      pstate_v
-    | _ ->
-      unsupported loc @@ "Initial env value of PSTATE is not a Value";
-    ) in
-    let lenv = LocalEnv.setVar loc (Var(0, ("PSTATE"))) (Val(pstate)) lenv in
-    let lenv = LocalEnv.setVar loc (Var(0, ("SCR_EL3"))) (Val(VBits({n=64; v=Z.zero;}))) lenv in
-    let lenv = LocalEnv.setVar loc (Var(0, ("SCTLR_EL1"))) (Val(VBits({n=64; v=Z.zero;}))) lenv in
-    (* set InGuardedPage to false *)
-    let lenv = LocalEnv.setVar loc (Var(0, ("InGuardedPage"))) (Val (VBool false)) lenv in
+    let lenv = try
+      (* get the pstate, then construct a new pstate where nRW=0, EL=0 & SP=0, then set the pstate *)
+      let (_, pstate) = LocalEnv.getVar loc (Var(0, ("PSTATE"))) lenv in
+      let pstate = (match pstate with
+      | Val(pstate_v) ->
+        let pstate_v = set_access_chain loc pstate_v [Field(Ident("EL"))] (VBits({n=2; v=Z.zero;})) in
+        let pstate_v = set_access_chain loc pstate_v [Field(Ident("SP"))] (VBits({n=1; v=Z.zero;})) in
+        let pstate_v = set_access_chain loc pstate_v [Field(Ident("nRW"))] (VBits({n=1; v=Z.zero;})) in
+        pstate_v
+      | _ ->
+        unsupported loc @@ "Initial env value of PSTATE is not a Value";
+      ) in
+      let lenv = LocalEnv.setVar loc (Var(0, ("PSTATE"))) (Val(pstate)) lenv in
+      let lenv = LocalEnv.setVar loc (Var(0, ("SCR_EL3"))) (Val(VBits({n=64; v=Z.zero;}))) lenv in
+      let lenv = LocalEnv.setVar loc (Var(0, ("SCTLR_EL1"))) (Val(VBits({n=64; v=Z.zero;}))) lenv in
+      (* set InGuardedPage to false *)
+      LocalEnv.setVar loc (Var(0, ("InGuardedPage"))) (Val (VBool false)) lenv
+    with _ ->
+      lenv
+    in
     let globals = IdentSet.of_list @@ List.map fst @@ Bindings.bindings (Eval.Env.readGlobals env) in
     lenv, globals
 

--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -847,6 +847,11 @@ and dis_expr loc x =
   | Val (VUninitialized _) -> internal_error loc @@ "dis_expr returning VUninitialized, invalidating assumption"
   | _ -> r
 
+and dis_unknown ty: expr =
+  match ty with
+  | Type_Tuple (tys) -> Expr_Tuple (List.map dis_unknown tys)
+  | _ -> Expr_Unknown(ty)
+
 and dis_expr' (loc: l) (x: AST.expr): sym rws =
     (match x with
     | Expr_If(ty, c, t, els, e) ->
@@ -925,7 +930,7 @@ and dis_expr' (loc: l) (x: AST.expr): sym rws =
             raise (EvalError (loc, "unary operation should have been removed"))
     | Expr_Unknown(t) -> (* TODO: Is this enough? *)
             let+ t' = dis_type loc t in
-            Exp (Expr_Unknown(t'))
+            Exp (dis_unknown t')
     | Expr_ImpDef(t, Some(s)) ->
             DisEnv.reads (fun config -> Val (Eval.Env.getImpdef loc config.eval_env s))
     | Expr_ImpDef(t, None) ->

--- a/libASL/dis.ml
+++ b/libASL/dis.ml
@@ -561,6 +561,46 @@ let rec ite_body stmts result =
   | (Stmt_ConstDecl _ )::es -> ite_body es result
   | _ -> None
 
+(** Recursive datatype to represent variable structure for tuples *)
+type var_structure = 
+  | VarLeaf of var
+  | VarTuple of var_structure list
+
+(** Build variable structure from type *)
+let rec build_var_structure (loc: l) (t: ty) (prefix: string): var_structure rws =
+  (match t with
+  | Type_Tuple tys ->
+      let+ structures = DisEnv.traverse (fun ty -> build_var_structure loc ty prefix) tys in
+      VarTuple structures
+  | _ ->
+      let+ temp = declare_fresh_named_var loc prefix t in
+      VarLeaf temp)
+
+(** Assign value to variable structure *)
+let rec assign_var_structure (loc: l) (structure: var_structure) (sym: sym): unit rws =
+  (match structure with
+  | VarLeaf var ->
+      assign_var loc var sym
+  | VarTuple structures ->
+      let syms = sym_of_tuple loc sym in
+      let rec assign_all structures syms =
+        (match structures, syms with
+        | [], [] -> DisEnv.unit
+        | structure::rest_structures, sym::rest_syms ->
+            let@ () = assign_var_structure loc structure sym in
+            assign_all rest_structures rest_syms
+        | _ -> internal_error loc "mismatch between tuple structures and symbols")
+      in
+      assign_all structures syms)
+
+(** Convert variable structure to expression *)
+let rec var_structure_to_expr (structure: var_structure): expr =
+  (match structure with
+  | VarLeaf var ->
+      var_expr var
+  | VarTuple structures ->
+      Expr_Tuple (List.map var_structure_to_expr structures))
+
 (** Symbolic implementation of an if statement that returns an expression
  *)
 let rec sym_if (loc: l) (t: ty) (test: sym rws) (tcase: sym rws) (fcase: sym rws): sym rws =
@@ -571,29 +611,36 @@ let rec sym_if (loc: l) (t: ty) (test: sym rws) (tcase: sym rws) (fcase: sym rws
   | Val _ -> failwith ("Split on non-boolean value")
   | Exp e ->
       let@ t = dis_type loc t in
-      let@ tmp = declare_fresh_named_var loc "If" t in
+      let@ structure = build_var_structure loc t "If" in
       (* Evaluate true branch statements. *)
       let@ (tenv,tstmts) = DisEnv.locally_
-          (tcase >>= assign_var loc tmp) in
+          (tcase >>= assign_var_structure loc structure) in
       let tstmts = flatten tstmts [] in
       (* Propagate incremented counter to env'. *)
       let@ env' = DisEnv.gets (fun env -> LocalEnv.sequence_merge env tenv) in
       (* Execute false branch statements with env'. *)
       let@ (fenv,fstmts) = DisEnv.locally_
-          (DisEnv.put env' >> fcase >>= assign_var loc tmp) in
+          (DisEnv.put env' >> fcase >>= assign_var_structure loc structure) in
       let@ () = DisEnv.join_locals tenv fenv in
       let fstmts = flatten fstmts [] in
-      match ite_body tstmts tmp, ite_body fstmts tmp with
-      | Some (Val _ as te), Some fe
-      | Some te, Some (Val _ as fe) ->
-          let@ () = DisEnv.write (Utils.butlast tstmts) in
-          let+ () = DisEnv.write (Utils.butlast fstmts) in
-          (match t with
-          | Type_Bits _ -> sym_ite_bits loc (Exp e) te fe
-          | _ -> sym_ite_bool loc (Exp e) te fe)
-      | _ ->
+      (* For single variable, try the ITE optimization *)
+      (match structure with
+      | VarLeaf tmp ->
+          (match ite_body tstmts tmp, ite_body fstmts tmp with
+          | Some (Val _ as te), Some fe
+          | Some te, Some (Val _ as fe) ->
+              let@ () = DisEnv.write (Utils.butlast tstmts) in
+              let+ () = DisEnv.write (Utils.butlast fstmts) in
+              (match t with
+              | Type_Bits _ -> sym_ite_bits loc (Exp e) te fe
+              | _ -> sym_ite_bool loc (Exp e) te fe)
+          | _ ->
+              let+ () = DisEnv.write [Stmt_If(e, tstmts, [], fstmts, loc)] in
+              Exp (var_expr tmp))
+      | VarTuple _ ->
+          (* For tuple types, generate if statement and return tuple expression *)
           let+ () = DisEnv.write [Stmt_If(e, tstmts, [], fstmts, loc)] in
-          Exp (var_expr tmp))
+          Exp (var_structure_to_expr structure)))
 
 (** Symbolic implementation of an if statement with no return *)
 and unit_if (loc: l) (test: sym rws) (tcase: unit rws) (fcase: unit rws): unit rws =

--- a/libASL/eval.ml
+++ b/libASL/eval.ml
@@ -493,38 +493,6 @@ let initializeGlobals (env: Env.t): unit =
     let g = Env.getGlobals env in
     g.bs <- Bindings.map (eval_uninitialized_to_defaults env) g.bs
 
-let initializeRegistersAndMemory (env: Env.t) (regs: bitvector list) (vecs: bitvector list): unit =
-    let d = VBits {n=64; v=Z.zero} in
-
-    let vals = List.mapi (fun i v -> (i, VBits v)) regs in
-    let arr = List.fold_left
-        (fun a (k,v) -> ImmutableArray.add k v a)
-        ImmutableArray.empty
-        vals
-    in
-    Env.setVar Unknown env (Ident "_R") (VArray (arr, d));
-
-    let vals = List.mapi (fun i v -> (i, VBits v)) vecs in
-    let arr = List.fold_left
-        (fun a (k,v) -> ImmutableArray.add k v a)
-        ImmutableArray.empty
-        vals
-    in
-    Env.setVar Unknown env (Ident "_Z") (VArray (arr, d));
-
-    (* Init memory *)
-    let ram = Primops.init_ram (char_of_int 0) in
-    ram.default <- None;
-    Env.setVar Unknown env (Ident "__Memory") (VRAM ram)
-
-let randomRegistersAndMemory (env: Env.t): unit =
-    let rnd n = Primops.({ n ; v = Z.random_bits n }) in
-    (* Init register array, should be 31 elements, each 64 bits wide *)
-    let regs = List.init 31 (fun i -> (rnd 64)) in
-    (* Init vector array, should be 32 elements, each 128 bits wide *)
-    let vecs = List.init 32 (fun i -> (rnd 128)) in
-    initializeRegistersAndMemory env regs vecs
-
 let isGlobalConst (env: Env.t) (id: AST.ident): bool =
     match Env.getGlobalConst env id with
     | _ -> true
@@ -1395,6 +1363,11 @@ let evaluation_environment (prelude: LoadASL.source) (files: LoadASL.source list
     Option.iter (fun env -> List.iter (evaluate_prj_minimal tcenv env) prjs) env;
     env
 
+let randomRegistersAndMemory (env: Env.t): unit =
+    try
+      eval_proccall Unknown env (FIdent ("random_state", 0)) [] []
+    with
+    | Return None -> ()
 
 (****************************************************************
  * End

--- a/libASL/support/native/solver.ml
+++ b/libASL/support/native/solver.ml
@@ -22,129 +22,105 @@ module Asl_utils = LibASL_stage0.Asl_utils
 
 let verbose = false
 
-let rec div_term a c =
-  let open AST in
-  match a with
-  | _ when a = c -> Some (Expr_LitInt "1")
-  | Expr_Parens a -> div_term a c
-  | Expr_TApply (FIdent ("mul_int",l),  [], [a ; b]) ->
-      (match div_term a c with
-      | Some r -> Some (Expr_TApply (FIdent ("mul_int",l),  [], [r ; b]))
-      | None ->
-          (match div_term b c with
-          | Some r -> Some (Expr_TApply (FIdent ("mul_int",l),  [], [a ; r]))
-          | None -> None))
-  | Expr_TApply (FIdent ("add_int",loc),  [], [a ; b]) ->
-      (match div_term a c, div_term b c with
-      | Some l, Some r -> Some (Expr_TApply (FIdent ("add_int",loc),  [], [l ; r]))
-      | _ -> None)
-  | _ -> None
+let uninterp ctx ufs x sort =
+  if verbose then Printf.printf "    Unable to translate %s - using as uninterpreted function\n" (Asl_utils.pp_expr x);
+  match List.assoc_opt x !ufs with
+  | Some uf -> uf
+  | None ->
+      let uf = Z3.Expr.mk_fresh_const ctx "UNINTERPRETED" sort in
+      ufs := (x, uf) :: !ufs;
+      uf
+
+let mk_mul a b = AST.Expr_TApply (FIdent ("mul_int",0), [], [a; b])
+let mk_add a b = AST.Expr_TApply (FIdent ("add_int",0), [], [a; b])
+let mk_one = AST.Expr_LitInt "1"
+
+(* Broadly assume division is exact. Encode this by multiplying by denominators. *)
+(* TODO: Unsound, should just show division is exact. *)
+let rec extract_div : AST.expr -> (AST.expr * AST.expr) = function
+  | Expr_TApply (FIdent ("add_int",_), [], [a; b]) ->
+      let (an,ad) = extract_div a in
+      let (bn,bd) = extract_div b in
+      (mk_add (mk_mul an bd) (mk_mul bn ad), mk_mul ad bd)
+  | Expr_TApply (FIdent ("mul_int",_), [], [a; b]) ->
+      let (an,ad) = extract_div a in
+      let (bn,bd) = extract_div b in
+      (mk_mul an bn, mk_mul ad bd)
+  | Expr_TApply (FIdent ("fdiv_int",_), [], [a; b]) -> (a,b)
+  | x -> (x,mk_one)
 
 let rec z3_of_bool (ctx: Z3.context) (ufs: (AST.expr * Z3.Expr.expr) list ref) (x: AST.expr): Z3.Expr.expr =
-    (match x with
+    match x with
     | Expr_Var(v) when AST.pprint_ident v = "TRUE" -> Z3.Boolean.mk_true ctx
     | Expr_Var(v) when AST.pprint_ident v = "FALSE" -> Z3.Boolean.mk_false ctx
     | Expr_Var(v) ->
         let boolsort = Z3.Boolean.mk_sort ctx in
         Z3.Expr.mk_const_s ctx (AST.pprint_ident v) boolsort
-    | Expr_Parens y -> z3_of_bool ctx ufs y
+
+    (* Bool Ops *)
     | Expr_TApply (FIdent ("eq_bool",_), [], [a; b]) ->
         let a = z3_of_bool ctx ufs a in
         let b = z3_of_bool ctx ufs b in
         Z3.Boolean.mk_eq ctx a b
-
     | Expr_TApply (FIdent ("not_bool",_), [], [a]) ->
         let a = z3_of_bool ctx ufs a in
         Z3.Boolean.mk_not ctx a
-
     | Expr_TApply (FIdent ("and_bool",_), [], [a; b]) ->
         let a = z3_of_bool ctx ufs a in
         let b = z3_of_bool ctx ufs b in
         Z3.Boolean.mk_and ctx [a;b]
-
     | Expr_TApply (FIdent ("or_bool",_), [], [a; b]) ->
         let a = z3_of_bool ctx ufs a in
         let b = z3_of_bool ctx ufs b in
         Z3.Boolean.mk_or ctx [a;b]
 
-    | Expr_TApply (FIdent ("eq_int",_), [], [a; b]) when a = b ->
-        Z3.Boolean.mk_eq ctx (z3_of_expr ctx ufs a) (z3_of_expr ctx ufs b)
-
-    | Expr_TApply (FIdent ("eq_int",_), [], [a; Expr_TApply (FIdent ("fdiv_int",_), [], [b; c])]) ->
-            Z3.Boolean.mk_eq ctx
-                (Z3.Arithmetic.mk_mul ctx [z3_of_expr ctx ufs c; z3_of_expr ctx ufs a])
-                (z3_of_expr ctx ufs b)
-
+    (* Int Ops *)
     | Expr_TApply (FIdent ("eq_int",_), [], [a; b]) ->
-        let a = z3_of_expr ctx ufs a in
-        let b = z3_of_expr ctx ufs b in
+        let (an,ad) = extract_div a in
+        let (bn,bd) = extract_div b in
+        let a = z3_of_expr ctx ufs (mk_mul an bd) in
+        let b = z3_of_expr ctx ufs (mk_mul bn ad) in
         Z3.Boolean.mk_eq ctx a b
-
     | Expr_TApply (FIdent ("lt_int",_), [], [a; b]) ->
         let a = z3_of_expr ctx ufs a in
         let b = z3_of_expr ctx ufs b in
         Z3.Arithmetic.mk_lt ctx a b
-
     | Expr_TApply (FIdent ("le_int",_), [], [a; b]) ->
         let a = z3_of_expr ctx ufs a in
         let b = z3_of_expr ctx ufs b in
         Z3.Arithmetic.mk_le ctx a b
-
     | Expr_TApply (FIdent ("gt_int",_), [], [a; b]) ->
         let a = z3_of_expr ctx ufs a in
         let b = z3_of_expr ctx ufs b in
         Z3.Arithmetic.mk_gt ctx a b
-
     | Expr_TApply (FIdent ("ge_int",_), [], [a; b]) ->
         let a = z3_of_expr ctx ufs a in
         let b = z3_of_expr ctx ufs b in
         Z3.Arithmetic.mk_ge ctx a b
 
-    | _ ->
-            if verbose then Printf.printf "    Unable to translate %s - using as uninterpreted function\n" (Asl_utils.pp_expr x);
-            let intsort = Z3.Boolean.mk_sort ctx in
-            (match List.assoc_opt x !ufs with
-            | None ->
-                    let uf = Z3.Expr.mk_fresh_const ctx "UNINTERPRETED" intsort in
-                    ufs := (x, uf) :: !ufs;
-                    uf
-            | Some uf ->
-                    uf
-            )
-    )
-
-
+    | _ -> uninterp ctx ufs x (Z3.Boolean.mk_sort ctx)
 
 and z3_of_expr (ctx: Z3.context) (ufs: (AST.expr * Z3.Expr.expr) list ref) (x: AST.expr): Z3.Expr.expr =
-    (match x with
+    match x with
     | Expr_Var(v) ->
         let intsort = Z3.Arithmetic.Integer.mk_sort ctx in
         Z3.Expr.mk_const_s ctx (AST.pprint_ident v) intsort
-    | Expr_Parens y -> z3_of_expr ctx ufs y
     | Expr_LitInt i -> Z3.Arithmetic.Integer.mk_numeral_s ctx i
 
-    (* todo: the following lines involving DIV are not sound *)
-    | Expr_TApply (FIdent ("mul_int",_), [], [Expr_TApply (FIdent ("fdiv_int",_), [], [a; b]); c]) when b = c -> z3_of_expr ctx ufs a
-    | Expr_TApply (FIdent ("mul_int",_), [], [a; Expr_TApply (FIdent ("fdiv_int",_), [], [b; c])]) when a = c -> z3_of_expr ctx ufs b
-    | Expr_TApply (FIdent ("fdiv_int",_), [], [a;b]) ->
-        (match div_term a b with
-        | Some r -> z3_of_expr ctx ufs r
-        | _ -> Z3.Arithmetic.mk_div ctx (z3_of_expr ctx ufs a) (z3_of_expr ctx ufs b))
-
-    | Expr_TApply (FIdent ("add_int",_), [], [Expr_TApply (FIdent ("fdiv_int",_), [], [a1; b1]);
-                                         Expr_TApply (FIdent ("fdiv_int",_), [], [a2; b2])])
-         when a1 = a2 && b1 = b2 && b1 = Expr_LitInt "2"
-         -> z3_of_expr ctx ufs a1
-
-    | Expr_TApply (FIdent ("add_int",_),  [], xs)    -> Z3.Arithmetic.mk_add ctx (List.map (z3_of_expr ctx ufs) xs)
-    | Expr_TApply (FIdent ("sub_int",_),  [], xs)    -> Z3.Arithmetic.mk_sub ctx (List.map (z3_of_expr ctx ufs) xs)
-    | Expr_TApply (FIdent ("mul_int",_),  [], xs)    -> Z3.Arithmetic.mk_mul ctx (List.map (z3_of_expr ctx ufs) xs)
+    | Expr_TApply (FIdent ("add_int",_),  [], xs) ->
+        Z3.Arithmetic.mk_add ctx (List.map (z3_of_expr ctx ufs) xs)
+    | Expr_TApply (FIdent ("sub_int",_),  [], xs) ->
+        Z3.Arithmetic.mk_sub ctx (List.map (z3_of_expr ctx ufs) xs)
+    | Expr_TApply (FIdent ("mul_int",_),  [], xs) ->
+        Z3.Arithmetic.mk_mul ctx (List.map (z3_of_expr ctx ufs) xs)
 
     | Expr_TApply (FIdent ("pow2_int",_),  [], [Expr_LitInt i]) when int_of_string i > 0 ->
         let i = int_of_string i in
         Z3.Arithmetic.mk_mul ctx (List.init i (fun _ -> Z3.Arithmetic.Integer.mk_numeral_i ctx 2))
     | Expr_TApply (FIdent ("pow2_int",_),  [], [Expr_LitInt i]) when int_of_string i = 0 ->
         Z3.Arithmetic.Integer.mk_numeral_i ctx 1
+
+    (* TODO: technically unsound, need proof that 0 <= i <= 30 *)
     | Expr_TApply (FIdent ("pow2_int",_),  [], [i]) ->
         let i = z3_of_expr ctx ufs i in
         let rec loop n =
@@ -159,18 +135,7 @@ and z3_of_expr (ctx: Z3.context) (ufs: (AST.expr * Z3.Expr.expr) list ref) (x: A
         let f = z3_of_expr ctx ufs f in
         Z3.Boolean.mk_ite ctx c t f
 
-    | _ ->
-            if verbose then Printf.printf "    Unable to translate %s - using as uninterpreted function\n" (Asl_utils.pp_expr x);
-            let intsort = Z3.Arithmetic.Integer.mk_sort ctx in
-            (match List.assoc_opt x !ufs with
-            | None ->
-                    let uf = Z3.Expr.mk_fresh_const ctx "UNINTERPRETED" intsort in
-                    ufs := (x, uf) :: !ufs;
-                    uf
-            | Some uf ->
-                    uf
-            )
-    )
+    | _ -> uninterp ctx ufs x (Z3.Arithmetic.Integer.mk_sort ctx)
 
 (** check that bs => cs *)
 let check_constraints (bs: AST.expr list) (cs: AST.expr list): bool =
@@ -187,5 +152,6 @@ let check_constraints (bs: AST.expr list) (cs: AST.expr list): bool =
     if verbose then Printf.printf "      - Checking %s\n" (Z3.Expr.to_string p);
     Z3.Solver.add solver [Z3.Boolean.mk_not z3_ctx p];
     let q = Z3.Solver.check solver [] in
-    if q <> UNSATISFIABLE then Printf.printf "Failed property %s\n" (Z3.Expr.to_string p);
+    if q = SATISFIABLE then Printf.printf "Failed property %s\n" (Z3.Expr.to_string p);
+    if q = UNKNOWN then Printf.printf "Unknown property %s\n" (Z3.Expr.to_string p);
     q = UNSATISFIABLE

--- a/libASL/support/native/solver.ml
+++ b/libASL/support/native/solver.ml
@@ -22,7 +22,100 @@ module Asl_utils = LibASL_stage0.Asl_utils
 
 let verbose = false
 
-let rec z3_of_expr (ctx: Z3.context) (ufs: (AST.expr * Z3.Expr.expr) list ref) (x: AST.expr): Z3.Expr.expr =
+let rec div_term a c =
+  let open AST in
+  match a with
+  | _ when a = c -> Some (Expr_LitInt "1")
+  | Expr_Parens a -> div_term a c
+  | Expr_TApply (FIdent ("mul_int",l),  [], [a ; b]) ->
+      (match div_term a c with
+      | Some r -> Some (Expr_TApply (FIdent ("mul_int",l),  [], [r ; b]))
+      | None ->
+          (match div_term b c with
+          | Some r -> Some (Expr_TApply (FIdent ("mul_int",l),  [], [a ; r]))
+          | None -> None))
+  | Expr_TApply (FIdent ("add_int",loc),  [], [a ; b]) ->
+      (match div_term a c, div_term b c with
+      | Some l, Some r -> Some (Expr_TApply (FIdent ("add_int",loc),  [], [l ; r]))
+      | _ -> None)
+  | _ -> None
+
+let rec z3_of_bool (ctx: Z3.context) (ufs: (AST.expr * Z3.Expr.expr) list ref) (x: AST.expr): Z3.Expr.expr =
+    (match x with
+    | Expr_Var(v) when AST.pprint_ident v = "TRUE" -> Z3.Boolean.mk_true ctx
+    | Expr_Var(v) when AST.pprint_ident v = "FALSE" -> Z3.Boolean.mk_false ctx
+    | Expr_Var(v) ->
+        let boolsort = Z3.Boolean.mk_sort ctx in
+        Z3.Expr.mk_const_s ctx (AST.pprint_ident v) boolsort
+    | Expr_Parens y -> z3_of_bool ctx ufs y
+    | Expr_TApply (FIdent ("eq_bool",_), [], [a; b]) ->
+        let a = z3_of_bool ctx ufs a in
+        let b = z3_of_bool ctx ufs b in
+        Z3.Boolean.mk_eq ctx a b
+
+    | Expr_TApply (FIdent ("not_bool",_), [], [a]) ->
+        let a = z3_of_bool ctx ufs a in
+        Z3.Boolean.mk_not ctx a
+
+    | Expr_TApply (FIdent ("and_bool",_), [], [a; b]) ->
+        let a = z3_of_bool ctx ufs a in
+        let b = z3_of_bool ctx ufs b in
+        Z3.Boolean.mk_and ctx [a;b]
+
+    | Expr_TApply (FIdent ("or_bool",_), [], [a; b]) ->
+        let a = z3_of_bool ctx ufs a in
+        let b = z3_of_bool ctx ufs b in
+        Z3.Boolean.mk_or ctx [a;b]
+
+    | Expr_TApply (FIdent ("eq_int",_), [], [a; b]) when a = b ->
+        Z3.Boolean.mk_eq ctx (z3_of_expr ctx ufs a) (z3_of_expr ctx ufs b)
+
+    | Expr_TApply (FIdent ("eq_int",_), [], [a; Expr_TApply (FIdent ("fdiv_int",_), [], [b; c])]) ->
+            Z3.Boolean.mk_eq ctx
+                (Z3.Arithmetic.mk_mul ctx [z3_of_expr ctx ufs c; z3_of_expr ctx ufs a])
+                (z3_of_expr ctx ufs b)
+
+    | Expr_TApply (FIdent ("eq_int",_), [], [a; b]) ->
+        let a = z3_of_expr ctx ufs a in
+        let b = z3_of_expr ctx ufs b in
+        Z3.Boolean.mk_eq ctx a b
+
+    | Expr_TApply (FIdent ("lt_int",_), [], [a; b]) ->
+        let a = z3_of_expr ctx ufs a in
+        let b = z3_of_expr ctx ufs b in
+        Z3.Arithmetic.mk_lt ctx a b
+
+    | Expr_TApply (FIdent ("le_int",_), [], [a; b]) ->
+        let a = z3_of_expr ctx ufs a in
+        let b = z3_of_expr ctx ufs b in
+        Z3.Arithmetic.mk_le ctx a b
+
+    | Expr_TApply (FIdent ("gt_int",_), [], [a; b]) ->
+        let a = z3_of_expr ctx ufs a in
+        let b = z3_of_expr ctx ufs b in
+        Z3.Arithmetic.mk_gt ctx a b
+
+    | Expr_TApply (FIdent ("ge_int",_), [], [a; b]) ->
+        let a = z3_of_expr ctx ufs a in
+        let b = z3_of_expr ctx ufs b in
+        Z3.Arithmetic.mk_ge ctx a b
+
+    | _ ->
+            if verbose then Printf.printf "    Unable to translate %s - using as uninterpreted function\n" (Asl_utils.pp_expr x);
+            let intsort = Z3.Boolean.mk_sort ctx in
+            (match List.assoc_opt x !ufs with
+            | None ->
+                    let uf = Z3.Expr.mk_fresh_const ctx "UNINTERPRETED" intsort in
+                    ufs := (x, uf) :: !ufs;
+                    uf
+            | Some uf ->
+                    uf
+            )
+    )
+
+
+
+and z3_of_expr (ctx: Z3.context) (ufs: (AST.expr * Z3.Expr.expr) list ref) (x: AST.expr): Z3.Expr.expr =
     (match x with
     | Expr_Var(v) ->
         let intsort = Z3.Arithmetic.Integer.mk_sort ctx in
@@ -33,20 +126,36 @@ let rec z3_of_expr (ctx: Z3.context) (ufs: (AST.expr * Z3.Expr.expr) list ref) (
     (* todo: the following lines involving DIV are not sound *)
     | Expr_TApply (FIdent ("mul_int",_), [], [Expr_TApply (FIdent ("fdiv_int",_), [], [a; b]); c]) when b = c -> z3_of_expr ctx ufs a
     | Expr_TApply (FIdent ("mul_int",_), [], [a; Expr_TApply (FIdent ("fdiv_int",_), [], [b; c])]) when a = c -> z3_of_expr ctx ufs b
+    | Expr_TApply (FIdent ("fdiv_int",_), [], [a;b]) ->
+        (match div_term a b with
+        | Some r -> z3_of_expr ctx ufs r
+        | _ -> Z3.Arithmetic.mk_div ctx (z3_of_expr ctx ufs a) (z3_of_expr ctx ufs b))
+
     | Expr_TApply (FIdent ("add_int",_), [], [Expr_TApply (FIdent ("fdiv_int",_), [], [a1; b1]);
                                          Expr_TApply (FIdent ("fdiv_int",_), [], [a2; b2])])
          when a1 = a2 && b1 = b2 && b1 = Expr_LitInt "2"
          -> z3_of_expr ctx ufs a1
-    | Expr_TApply (FIdent ("eq_int",_), [], [a; Expr_TApply (FIdent ("fdiv_int",_), [], [b; c])]) ->
-            Z3.Boolean.mk_eq ctx
-                (Z3.Arithmetic.mk_mul ctx [z3_of_expr ctx ufs c; z3_of_expr ctx ufs a])
-                (z3_of_expr ctx ufs b)
 
     | Expr_TApply (FIdent ("add_int",_),  [], xs)    -> Z3.Arithmetic.mk_add ctx (List.map (z3_of_expr ctx ufs) xs)
     | Expr_TApply (FIdent ("sub_int",_),  [], xs)    -> Z3.Arithmetic.mk_sub ctx (List.map (z3_of_expr ctx ufs) xs)
     | Expr_TApply (FIdent ("mul_int",_),  [], xs)    -> Z3.Arithmetic.mk_mul ctx (List.map (z3_of_expr ctx ufs) xs)
-    | Expr_TApply (FIdent ("fdiv_int",_), [], [a;b]) -> Z3.Arithmetic.mk_div ctx (z3_of_expr ctx ufs a) (z3_of_expr ctx ufs b)
-    | Expr_TApply (FIdent ("eq_int",_),   [], [a;b]) -> Z3.Boolean.mk_eq ctx (z3_of_expr ctx ufs a) (z3_of_expr ctx ufs b)
+
+    | Expr_TApply (FIdent ("pow2_int",_),  [], [Expr_LitInt i]) when int_of_string i > 0 ->
+        let i = int_of_string i in
+        Z3.Arithmetic.mk_mul ctx (List.init i (fun _ -> Z3.Arithmetic.Integer.mk_numeral_i ctx 2))
+    | Expr_TApply (FIdent ("pow2_int",_),  [], [Expr_LitInt i]) when int_of_string i = 0 ->
+        Z3.Arithmetic.Integer.mk_numeral_i ctx 1
+    | Expr_TApply (FIdent ("pow2_int",_),  [], [i]) ->
+        let two = Z3.Arithmetic.Integer.mk_numeral_i ctx 2 in
+        let arg = z3_of_expr ctx ufs i in
+        Z3.Arithmetic.mk_power ctx two arg
+
+    | Expr_If (_, c, t, [], f) ->
+        let c = z3_of_bool ctx ufs c in
+        let t = z3_of_expr ctx ufs t in
+        let f = z3_of_expr ctx ufs f in
+        Z3.Boolean.mk_ite ctx c t f
+
     | _ ->
             if verbose then Printf.printf "    Unable to translate %s - using as uninterpreted function\n" (Asl_utils.pp_expr x);
             let intsort = Z3.Arithmetic.Integer.mk_sort ctx in
@@ -69,8 +178,8 @@ let check_constraints (bs: AST.expr list) (cs: AST.expr list): bool =
     let z3_ctx = Z3.mk_context [] in
     let solver = Z3.Solver.mk_simple_solver z3_ctx in
     let ufs = ref [] in (* uninterpreted function list *)
-    let bs' = List.map (z3_of_expr z3_ctx ufs) bs in
-    let cs' = List.map (z3_of_expr z3_ctx ufs) cs in
+    let bs' = List.map (fun e -> z3_of_bool z3_ctx ufs (Asl_utils.prune_parens e)) bs in
+    let cs' = List.map (fun e -> z3_of_bool z3_ctx ufs (Asl_utils.prune_parens e)) cs in
     let p = Z3.Boolean.mk_implies z3_ctx (Z3.Boolean.mk_and z3_ctx bs') (Z3.Boolean.mk_and z3_ctx cs') in
     if verbose then Printf.printf "      - Checking %s\n" (Z3.Expr.to_string p);
     Z3.Solver.add solver [Z3.Boolean.mk_not z3_ctx p];

--- a/libASL/support/native/solver.ml
+++ b/libASL/support/native/solver.ml
@@ -146,9 +146,12 @@ and z3_of_expr (ctx: Z3.context) (ufs: (AST.expr * Z3.Expr.expr) list ref) (x: A
     | Expr_TApply (FIdent ("pow2_int",_),  [], [Expr_LitInt i]) when int_of_string i = 0 ->
         Z3.Arithmetic.Integer.mk_numeral_i ctx 1
     | Expr_TApply (FIdent ("pow2_int",_),  [], [i]) ->
-        let two = Z3.Arithmetic.Integer.mk_numeral_i ctx 2 in
-        let arg = z3_of_expr ctx ufs i in
-        Z3.Arithmetic.mk_power ctx two arg
+        let i = z3_of_expr ctx ufs i in
+        let rec loop n =
+          if n = 0 then Z3.Arithmetic.Integer.mk_numeral_i ctx 1
+          else Z3.Boolean.mk_ite ctx (Z3.Boolean.mk_eq ctx (Z3.Arithmetic.Integer.mk_numeral_i ctx n) i) (Z3.Arithmetic.Integer.mk_numeral_i ctx (1 lsl n)) (loop (n - 1))
+        in
+        loop 30
 
     | Expr_If (_, c, t, [], f) ->
         let c = z3_of_bool ctx ufs c in
@@ -184,5 +187,5 @@ let check_constraints (bs: AST.expr list) (cs: AST.expr list): bool =
     if verbose then Printf.printf "      - Checking %s\n" (Z3.Expr.to_string p);
     Z3.Solver.add solver [Z3.Boolean.mk_not z3_ctx p];
     let q = Z3.Solver.check solver [] in
-    if q = SATISFIABLE then Printf.printf "Failed property %s\n" (Z3.Expr.to_string p);
+    if q <> UNSATISFIABLE then Printf.printf "Failed property %s\n" (Z3.Expr.to_string p);
     q = UNSATISFIABLE

--- a/libASL/symbolic.ml
+++ b/libASL/symbolic.ml
@@ -73,6 +73,7 @@ let rec val_expr (v: Value.value): AST.expr =
       let v = Z.format ("%0" ^ string_of_int n ^ "b") v in
       let m = Z.format ("%0" ^ string_of_int n ^ "b") m in
       Expr_LitMask (String.mapi (fun i c -> if String.get m i = '1' then c else 'x') v)
+  | VUninitialized(ty) -> Expr_Unknown(ty)
   | _ -> failwith @@ "Casting unhandled value type to expression: " ^ pp_value v
 
 let rec val_initialised (v: value): bool =
@@ -252,11 +253,18 @@ let expr_true    = Expr_Var (Ident "TRUE")
 let expr_false   = Expr_Var (Ident "FALSE")
 let sym_zeros n  = Val (VBits (prim_zeros_bits (Z.of_int n)))
 
+let int_or_enum (loc: AST.l) (x: value): bigint =
+    (match x with
+    | VInt i -> i
+    | VEnum (_, i) -> Z.of_int i
+    | _ -> raise (EvalError (loc, "integer expected. Got " ^ pp_value x))
+    )
+
 let rec sym_eq_int loc x y =
   let x = eval_lit x in
   let y = eval_lit y in
   match x, y with
-  | Val x, Val y -> Val (VBool (prim_eq_int (to_integer loc x) (to_integer loc y)))
+  | Val x, Val y -> Val (VBool (prim_eq_int (int_or_enum loc x) (int_or_enum loc y)))
   (* (x = x) = True *)
   | Exp x, Exp y when x = y -> Val (VBool (true))
   (* (x = x + v) = (v = 0) *)

--- a/libASL/symbolic.ml
+++ b/libASL/symbolic.ml
@@ -114,6 +114,8 @@ let expr_of_int n =
     literal expressions into values. *)
 let sym_of_expr (e: expr): sym =
   match e with
+  | Expr_Var id when pprint_ident id = "TRUE" -> Val (VBool true)
+  | Expr_Var id when pprint_ident id = "FALSE" -> Val (VBool false)
   | Expr_LitInt(i) ->    (Val (from_intLit i))
   | Expr_LitHex(i) ->    (Val (from_hexLit i))
   | Expr_LitReal(r) ->   (Val (from_realLit r))
@@ -181,7 +183,7 @@ let int_of_sym (e: sym): int =
 let sym_of_tuple (loc: AST.l) (v: sym): sym list  =
   match v with
   | Val (VTuple vs) -> (List.map (fun v -> Val v) vs)
-  | Exp (Expr_Tuple vs) -> (List.map (fun v -> Exp v) vs)
+  | Exp (Expr_Tuple vs) -> (List.map sym_of_expr vs)
   | _ -> raise (EvalError (loc, "tuple expected. Got "^ pp_sym v))
 
 let eval_lit (x: sym) =

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -702,11 +702,15 @@ let z3_pure_ops = [
 (** Attempt to extract a constant expression bounding reachability, implied by the provided term *)
 let rec to_constant_expr (env: Env.t) (e: AST.expr): AST.expr option =
     match e with
-    | Expr_Parens e -> to_constant_expr env e
+    | Expr_Parens e -> Option.map (fun v -> Expr_Parens v) (to_constant_expr env e)
     | Expr_LitInt _
     | Expr_Var (Ident "TRUE")
     | Expr_Var (Ident "FALSE") -> Some e
     | Expr_Var v when Env.isConstant env v -> Some e
+    | Expr_If(ty, c, t, [], f) ->
+        (match to_constant_expr env c, to_constant_expr env t, to_constant_expr env f with
+        | Some c', Some t', Some f' -> Some (Expr_If(ty, c', t', [], f'))
+        | _ -> None)
     | Expr_TApply (FIdent("and_bool", i), [], es) ->
         let es = List.filter_map (to_constant_expr env) es in
         (match es with
@@ -1011,7 +1015,9 @@ let addConstraint env loc e =
     let e = Visitor.visit_expr subst_consts e in
     match to_constant_expr env e with
     | Some e -> Env.addConstraint env loc e
-    | None -> ()
+    | None ->
+        if verbose then Printf.printf "    - Skipping constraint: %s\n" (pp_expr e);
+        ()
 
 (** Unify two types
 

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -63,6 +63,17 @@ let mk_add_int (x: AST.expr) (y: AST.expr): AST.expr =
 let mk_sub_int (x: AST.expr) (y: AST.expr): AST.expr =
     Expr_TApply (FIdent ("sub_int",0), [], [x; y])
 
+(** Construct expression "and_bool(x, y)" *)
+let mk_and_bool (x: AST.expr) (y: AST.expr): AST.expr =
+    Expr_TApply (FIdent ("and_bool",0), [], [x; y])
+
+(** Construct expression "not_bool(x)" *)
+let mk_not_bool (x: AST.expr): AST.expr =
+    Expr_TApply (FIdent ("not_bool",0), [], [x])
+
+(** Construct expression "TRUE" *)
+let mk_true = Expr_Var (Ident "TRUE")
+
 (** Construct expression "(0 + x1) + ... + xn" *)
 let mk_add_ints (xs: AST.expr list): AST.expr =
     List.fold_left mk_add_int (Expr_LitInt "0") xs
@@ -545,6 +556,8 @@ module Env : sig
     val getConstraints      : t -> AST.expr list
     val setReturnType       : t -> AST.ty -> unit
     val getReturnType       : t -> AST.ty option
+
+    val isConstant          : t -> AST.ident -> bool
 end = struct
     type t = {
         globals             : GlobalEnv.t;
@@ -557,7 +570,7 @@ end = struct
         mutable implicits   : AST.ty Bindings.t ref;
 
         (* constraints collected while typechecking current expression/assignment *)
-        mutable constraints : AST.expr list;
+        mutable constraints : (AST.expr list) list;
     }
 
     let mkEnv (globalEnv: GlobalEnv.t) = {
@@ -566,7 +579,7 @@ end = struct
         locals      = [Bindings.empty];
         modified    = IdentSet.empty;
         implicits   = ref Bindings.empty;
-        constraints = [];
+        constraints = [[]];
     }
 
     (* todo: would it be better to make Env a subclass of GlobalEnv
@@ -582,7 +595,7 @@ end = struct
             locals      = Bindings.empty :: parent.locals;
             modified    = IdentSet.empty;
             implicits   = parent.implicits;
-            constraints = parent.constraints;
+            constraints = [] :: parent.constraints;
         } in
         let r = k child in
         parent.modified <- IdentSet.union parent.modified child.modified;
@@ -595,7 +608,7 @@ end = struct
             locals      = Bindings.empty :: parent.locals;
             modified    = IdentSet.empty;
             implicits   = parent.implicits;
-            constraints = parent.constraints;
+            constraints = [] :: parent.constraints;
         } in
         let r = k child in
         parent.modified <- IdentSet.union parent.modified child.modified;
@@ -653,10 +666,13 @@ end = struct
         env.modified <- IdentSet.add v env.modified
 
     let addConstraint (env: t) (loc: AST.l) (c: AST.expr): unit =
-        env.constraints <- c :: env.constraints
+        if verbose then Printf.printf "    - Adding constraint: %s\n" (pp_expr c);
+        match env.constraints with
+        | cs::css -> env.constraints <- (c::cs)::css
+        | _ -> failwith "addConstraint"
 
     let getConstraints (env: t): AST.expr list =
-        env.constraints
+        List.flatten env.constraints
 
     let setReturnType (env: t) (ty: AST.ty): unit =
         env.rty <- Some ty
@@ -664,7 +680,47 @@ end = struct
     let getReturnType (env: t): AST.ty option =
         env.rty
 
+    let isConstant (env: t) (v: AST.ident): bool =
+      true
+        (*GlobalEnv.getConstant env.globals v <> None ||
+        (not (IdentSet.mem v env.modified) && List.exists (fun m -> Bindings.mem v m) env.locals) *)
+
 end
+
+(****************************************************************)
+(** {2 Path-sensitive analysis helper functions}               *)
+(****************************************************************)
+
+(** Z3-compatible pure operations for constant conditions *)
+let z3_pure_ops = [
+    (* Boolean operations *)
+    "eq_bool"; "ne_bool"; "not_bool"; "and_bool"; "or_bool"; "implies_bool";
+    (* Integer operations *)
+    "eq_int"; "ne_int"; "le_int"; "lt_int"; "ge_int"; "gt_int";
+    "add_int"; "sub_int"; "mul_int"; "neg_int"; "pow2_int"
+]
+
+(** Attempt to extract a constant expression bounding reachability, implied by the provided term *)
+let rec to_constant_expr (env: Env.t) (e: AST.expr): AST.expr option =
+    match e with
+    | Expr_Parens e -> to_constant_expr env e
+    | Expr_LitInt _
+    | Expr_Var (Ident "TRUE")
+    | Expr_Var (Ident "FALSE") -> Some e
+    | Expr_Var v when Env.isConstant env v -> Some e
+    | Expr_TApply (FIdent("and_bool", i), [], es) ->
+        let es = List.filter_map (to_constant_expr env) es in
+        (match es with
+        | [] -> None
+        | [e] -> Some e
+        | es -> Some (Expr_TApply (FIdent("and_bool", i), [], es)))
+    | Expr_TApply (FIdent(f, i), [], es) when List.mem f z3_pure_ops ->
+        let es' = List.filter_map (to_constant_expr env) es in
+        if List.length es <> List.length es' then None
+        else Some (Expr_TApply (FIdent(f, i), [], es'))
+    | _ -> None
+
+let is_constant_expr env e = (to_constant_expr env e = Some e)
 
 (****************************************************************)
 (** {2 Unification}                                             *)
@@ -874,6 +930,7 @@ class unifier (loc: AST.l) (assumptions: expr list) = object (self)
                 renamings#pp "      Renaming: ";
                 Bindings.iter (fun v e -> Printf.printf "      Bind: %s -> %s\n" (pprint_ident v) (ppp_expr e)) bindings
             end;
+            List.iter (fun c -> Printf.printf "      Assumption: %s\n" (ppp_expr c)) assumptions;
             List.iter (fun c -> Printf.printf "      Constraint: %s\n" (ppp_expr c)) constraints;
             flush stdout;
             raise (TypeError (loc, "Type mismatch"))
@@ -951,9 +1008,11 @@ let unify_ixtype (u: unifier) (ty1: AST.ixtype) (ty2: AST.ixtype): unit =
     )
 
 let addConstraint env loc e =
-  let subst_consts = new substFunClass (GlobalEnv.getConstant (Env.globals env)) in
-  let e = Visitor.visit_expr subst_consts e in
-  Env.addConstraint env loc e
+    let subst_consts = new substFunClass (GlobalEnv.getConstant (Env.globals env)) in
+    let e = Visitor.visit_expr subst_consts e in
+    match to_constant_expr env e with
+    | Some e -> Env.addConstraint env loc e
+    | None -> ()
 
 (** Unify two types
 
@@ -1320,17 +1379,44 @@ and tc_slice_expr (env: Env.t) (u: unifier) (loc: AST.l) (x: expr) (ss: (AST.sli
     | _ -> raise (TypeError (loc, "slice of expr"))
     )
 
+(* Join two types under some constant condition *)
+and cond_join_typs env u loc c tty ety =
+    let bail tty ety =
+      check_type env u loc tty ety;
+      tty
+    in
+    let rec loop tty ety =
+        match tty, ety with
+        | _ when tty = ety -> tty
+        | Type_Bits(n), Type_Bits(m) -> Type_Bits (Expr_If (type_integer, c, n, [], m))
+        | Type_Tuple(ttys), Type_Tuple(etys) ->
+                let tys = List.map2 loop ttys etys in
+                Type_Tuple(tys)
+        | _ -> bail tty ety
+    in
+    if is_constant_expr env c then loop tty ety else bail tty ety
+
+(* Type check an expression if *)
+and tc_e_if env u loc bodies default =
+    match bodies with
+    | (E_Elsif_Cond(c,s))::bodies ->
+            let c' = check_expr env loc type_bool c in
+            let (s',tty) = tc_expr env u loc s in
+            let (ety,bodies',default') = tc_e_if env u loc bodies default in
+            let ty = cond_join_typs env u loc c' tty ety in
+            (ty,E_Elsif_Cond(c',s')::bodies',default')
+    | [] ->
+            let (default',dty) = tc_expr env u loc default in
+            (dty,[],default')
+
 (** Typecheck expression *)
 and tc_expr (env: Env.t) (u: unifier) (loc: AST.l) (x: AST.expr): (AST.expr * AST.ty) =
     (match x with
     | Expr_If(_, c, t, els, e) ->
-            let c'        = check_expr env loc type_bool c in
-            let (t', tty)     = tc_expr env u loc t in
-            let (els', eltys) = List.split (List.map (tc_e_elsif env u loc) els) in
-            let (e', ety)     = tc_expr env u loc e in
-            List.iter (fun elty -> check_type env u loc tty elty) eltys;
-            check_type env u loc tty ety;
-            (Expr_If(tty, c', t', els', e'), tty)
+            let bodies = E_Elsif_Cond(c,t)::els in
+            let (ty,bodies',default') = tc_e_if env u loc bodies e in
+            let E_Elsif_Cond(c',t') = List.hd bodies' in
+            (Expr_If(ty, c', t', List.tl bodies', default'), ty)
     | Expr_Binop(x, Binop_Eq, Expr_LitMask(y)) ->
             (* syntactic sugar *)
             tc_expr env u loc (Expr_In(x, Pat_LitMask y))
@@ -1772,24 +1858,42 @@ let rec tc_stmts (env: Env.t) (loc: AST.l) (xs: AST.stmt list): AST.stmt list =
     ) env in
     List.concat rss
 
-(** Typecheck 'if expr then stmt' *)
-and tc_s_elsif (env: Env.t) (loc: AST.l) (x: AST.s_elsif): AST.s_elsif =
-    (match x with
-    | S_Elsif_Cond(c, s) ->
-            let c' = check_expr env loc type_bool c in
-            let s' = tc_stmts env loc s in
-            S_Elsif_Cond(c', s')
-    )
+(** Typecheck list of statements guarded by some condition *)
+and tc_stmts_with_cond (env: Env.t) (loc: AST.l) (c: AST.expr) (xs: AST.stmt list): AST.stmt list =
+    let rss = Env.nest (fun env' ->
+        addConstraint env' loc c;
+        List.map (fun s ->
+            let s' = tc_stmt env' s in
+            let imps = Env.getImplicits env' in
+            List.iter (fun (v, ty) -> Env.addLocalVar env' loc v ty) imps;
+            let decls = declare_implicits loc imps in
+            if verbose && decls <> [] then Printf.printf "Implicit decls: %s %s" (pp_loc loc) (Utils.to_string (PP.pp_indented_block decls));
+            List.append decls [s']
+        ) xs
+    ) env in
+    List.concat rss
+
+and tc_s_elsif (env: Env.t) (loc: AST.l) (bodies: s_elsif list) default =
+    let rec loop bodies reach = match bodies with
+    | (S_Elsif_Cond(c,s))::bodies ->
+        let c' = check_expr env loc type_bool c in
+        let s' = tc_stmts_with_cond env loc (mk_and_bool reach c') s in
+        let (bodies',default') = loop bodies (mk_and_bool reach (mk_not_bool c')) in
+        (S_Elsif_Cond(c',s')::bodies',default')
+    | [] ->
+        let default' = tc_stmts_with_cond env loc reach default in
+        ([],default')
+    in
+    loop bodies mk_true
 
 (** Typecheck case alternative *)
-and tc_alt (env: Env.t) (loc: AST.l) (ty: AST.ty) (x: AST.alt): AST.alt =
-    (match x with
-    | Alt_Alt(ps, oc, b) ->
-            let ps' = List.map (tc_pattern env loc ty) ps in
-            let oc' = map_option (fun c -> check_expr env loc type_bool c) oc in
-            let b' = tc_stmts env loc b in
-            Alt_Alt(ps', oc', b')
-    )
+and tc_alt (env: Env.t) (loc: AST.l) (ty: AST.ty) (e: AST.expr) (Alt_Alt(ps, oc, b): AST.alt): AST.alt =
+    let ps' = List.map (tc_pattern env loc ty) ps in
+    let oc' = map_option (fun c -> check_expr env loc type_bool c) oc in
+    let b' = match ps with
+    | [Pat_LitInt l] -> tc_stmts_with_cond env loc (mk_eq_int e (Expr_LitInt l)) b
+    | _ -> tc_stmts env loc b in
+    Alt_Alt(ps', oc', b')
 
 (** Typecheck exception catcher 'when expr stmt' *)
 and tc_catcher (env: Env.t) (loc: AST.l) (x: AST.catcher): AST.catcher =
@@ -1875,9 +1979,7 @@ and tc_stmt (env: Env.t) (x: AST.stmt): AST.stmt =
             Stmt_ProcReturn(loc)
     | Stmt_Assert(e, loc) ->
             let e' = check_expr env loc type_bool e in
-            (match prune_parens e' with
-            | Expr_TApply (FIdent("eq_int",_), _, _) -> addConstraint env loc e'
-            | e -> ());
+            addConstraint env loc e';
             Stmt_Assert(e', loc)
     | Stmt_Unpred(loc) ->
             Stmt_Unpred(loc)
@@ -1911,17 +2013,16 @@ and tc_stmt (env: Env.t) (x: AST.stmt): AST.stmt =
             ) in
             let e' = check_expr env loc ty e in
             Stmt_DecodeExecute(i, e', loc)
-    | Stmt_If(c, t, els, e, loc) ->
-            let c'   = check_expr env loc type_bool c in
-            let t'   = tc_stmts env loc t in
-            let els' = List.map (tc_s_elsif env loc) els in
-            let e'   = tc_stmts env loc e in
-            Stmt_If(c', t', els', e', loc)
+    | Stmt_If(c, t, els, default, loc) ->
+            let bodies = S_Elsif_Cond(c,t)::els in
+            let (bodies',default') = tc_s_elsif env loc bodies default in
+            let S_Elsif_Cond(c', t') = List.hd bodies' in
+            Stmt_If(c', t', List.tl bodies', default', loc)
     | Stmt_Case(e, alts, odefault, loc) ->
             let (s, (e', ty')) = with_unify env loc (fun u -> tc_expr env u loc e) in
             let e''       = unify_subst_e  s e' in
             let ty''      = unify_subst_ty s ty' in
-            let alts'     = List.map (tc_alt env loc ty'') alts in
+            let alts'     = List.map (tc_alt env loc ty'' e'') alts in
             let odefault' = map_option (fun b -> tc_stmts env loc b) odefault in
             Stmt_Case(e'', alts', odefault', loc)
     | Stmt_For(v, start, dir, stop, b, loc) ->

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -950,6 +950,11 @@ let unify_ixtype (u: unifier) (ty1: AST.ixtype) (ty2: AST.ixtype): unit =
     | _ -> ()
     )
 
+let addConstraint env loc e =
+  let subst_consts = new substFunClass (GlobalEnv.getConstant (Env.globals env)) in
+  let e = Visitor.visit_expr subst_consts e in
+  Env.addConstraint env loc e
+
 (** Unify two types
 
     This performs a structural match on two types - ignoring the dependent type part
@@ -1811,7 +1816,7 @@ and tc_stmt (env: Env.t) (x: AST.stmt): AST.stmt =
             let ty' = tc_type env loc ty in
             let i'  = check_expr env loc ty' i in
             Env.addLocalVar env loc v ty';
-            if ty' = type_integer then Env.addConstraint env loc (mk_eq_int (Expr_Var v) i');
+            if ty' = type_integer then addConstraint env loc (mk_eq_int (Expr_Var v) i');
             Stmt_ConstDecl(ty', v, i', loc)
     | Stmt_Assign(l, r, loc) ->
             let (s, (r', rty, l', imps)) = with_unify env loc (fun u ->
@@ -1870,6 +1875,9 @@ and tc_stmt (env: Env.t) (x: AST.stmt): AST.stmt =
             Stmt_ProcReturn(loc)
     | Stmt_Assert(e, loc) ->
             let e' = check_expr env loc type_bool e in
+            (match prune_parens e' with
+            | Expr_TApply (FIdent("eq_int",_), _, _) -> addConstraint env loc e'
+            | e -> ());
             Stmt_Assert(e', loc)
     | Stmt_Unpred(loc) ->
             Stmt_Unpred(loc)

--- a/libASL/tcheck.ml
+++ b/libASL/tcheck.ml
@@ -681,9 +681,8 @@ end = struct
         env.rty
 
     let isConstant (env: t) (v: AST.ident): bool =
-      true
-        (*GlobalEnv.getConstant env.globals v <> None ||
-        (not (IdentSet.mem v env.modified) && List.exists (fun m -> Bindings.mem v m) env.locals) *)
+        let imps = !(env.implicits) in
+        GlobalEnv.getConstant env.globals v <> None || (not (Bindings.mem v imps))
 
 end
 
@@ -696,7 +695,7 @@ let z3_pure_ops = [
     (* Boolean operations *)
     "eq_bool"; "ne_bool"; "not_bool"; "and_bool"; "or_bool"; "implies_bool";
     (* Integer operations *)
-    "eq_int"; "ne_int"; "le_int"; "lt_int"; "ge_int"; "gt_int";
+    "eq_int"; "ne_int"; "le_int"; "lt_int"; "ge_int"; "gt_int"; "fdiv_int";
     "add_int"; "sub_int"; "mul_int"; "neg_int"; "pow2_int"
 ]
 
@@ -1388,6 +1387,10 @@ and cond_join_typs env u loc c tty ety =
     let rec loop tty ety =
         match tty, ety with
         | _ when tty = ety -> tty
+        | Type_Bits(Expr_Var v), _ when u#isFresh v ->
+            bail tty ety
+        | _, Type_Bits(Expr_Var v) when u#isFresh v ->
+            bail tty ety
         | Type_Bits(n), Type_Bits(m) -> Type_Bits (Expr_If (type_integer, c, n, [], m))
         | Type_Tuple(ttys), Type_Tuple(etys) ->
                 let tys = List.map2 loop ttys etys in

--- a/libASL/testing.ml
+++ b/libASL/testing.ml
@@ -331,7 +331,7 @@ let field_vals_flags_only (enc: encoding) (name: string) (wd: int): int list =
   | _ when Utils.startswith name "uimm" -> [1]
   | _ when Utils.startswith name "scale" -> [0]
   | _, ("b40") -> [0;1;ones]
-  | _ -> List.init bound (fun x -> x)
+  | _ -> List.init (min 256 bound) (fun x -> x)
 
 let enumerate_encoding (enc: encoding) (field_vals: string -> int -> int list): encoding_tree =
   let Encoding_Block(name, iset, fields, opcode, guard, unpreds, stmts, loc) = enc in
@@ -417,7 +417,7 @@ let op_test_opcode (env: Env.t) (iset: string) (op: int): Env.t opresult =
   op_compare (evalenv, disevalenv)
 
 let get_opcodes (opt_verbose: bool ref) (iset: string) (instr: string) (env: Env.t): (string * instr_field list * ((int * bool) list) option) list =
-  if !opt_verbose then Printf.printf "Coverage for encoding %s\n" instr;
+  if !opt_verbose then Printf.printf "Coverage for encoding %s\n%!" instr;
 
   let re = Str.regexp instr in
   let encoding_matches = function

--- a/libASL/testing.ml
+++ b/libASL/testing.ml
@@ -331,6 +331,107 @@ let field_vals_flags_only (enc: encoding) (name: string) (wd: int): int list =
   | _ when Utils.startswith name "uimm" -> [1]
   | _ when Utils.startswith name "scale" -> [0]
   | _, ("b40") -> [0;1;ones]
+
+  (* RISCV common cases *)
+  | _ when Utils.startswith name "rs" -> [0;1;2;ones]
+  | _ when Utils.startswith name "rd" -> [0;1;2;ones]
+  | _ when Utils.startswith name "vs" -> [0;1;2;ones]
+  | _ when Utils.startswith name "vd" -> [0;1;2;ones]
+  | _, "rm" -> [ 0; 1; 2; 3; 4; 7 ]
+
+  (* Just the entire opcode as a field... *)
+  | Ident "ILLEGAL_0", _ -> [0]
+  | Ident "FENCE_RESERVED_0", "fm" -> [0]
+  | Ident "FENCE_RESERVED_0", "pred" -> [0]
+  | Ident "FENCE_RESERVED_0", "succ" -> [0]
+
+  (* Auto-generated *)
+  | Ident "AMO_0", "op" -> [ 1; 0; 4; 12; 8; 16; 20; 24; 28 ]
+  | Ident "BTYPE_0", "op" -> [ 0; 1; 4; 5; 6; 7 ]
+  | Ident "CSRImm_0", "op" -> [ 1; 2; 3 ]
+  | Ident "CSRReg_0", "op" -> [ 1; 2; 3 ]
+  | Ident "FVFMATYPE_0", "funct6" -> [ 40; 41; 42; 43; 44; 45; 46; 47 ]
+  | Ident "FVFMTYPE_0", "funct6" -> [ 24; 25; 27; 28; 29; 31 ]
+  | Ident "FVFTYPE_0", "funct6" -> [ 0; 2; 4; 6; 8; 9; 10; 14; 15; 32; 33; 36; 39 ]
+  | Ident "FVVMATYPE_0", "funct6" -> [ 40; 41; 42; 43; 44; 45; 46; 47 ]
+  | Ident "FVVMTYPE_0", "funct6" -> [ 24; 25; 27; 28 ]
+  | Ident "FVVTYPE_0", "funct6" -> [ 0; 2; 4; 6; 8; 9; 10; 32; 36 ]
+  | Ident "FWFTYPE_0", "funct6" -> [ 52; 54 ]
+  | Ident "FWVFMATYPE_0", "funct6" -> [ 60; 61; 62; 63 ]
+  | Ident "FWVFTYPE_0", "funct6" -> [ 48; 50; 56 ]
+  | Ident "FWVTYPE_0", "funct6" -> [ 52; 54 ]
+  | Ident "FWVVMATYPE_0", "funct6" -> [ 60; 61; 62; 63 ]
+  | Ident "FWVVTYPE_0", "funct6" -> [ 48; 50; 56 ]
+  | Ident "ITYPE_0", "op" -> [ 0; 2; 3; 7; 6; 4 ]
+  | Ident "LOAD_0", "is_unsigned" -> [ 1; 0 ]
+  | Ident "LOAD_0", "width" -> [ 0; 1; 2; 3 ]
+  | Ident "MMTYPE_0", "funct6" -> [ 25; 29; 24; 27; 26; 30; 28; 31 ]
+  | Ident "MUL_0", "mul_opXN" -> [ 0; 1; 2; 3 ]
+  | Ident "MVVMATYPE_0", "funct6" -> [ 45; 47; 41; 43 ]
+  | Ident "MVVTYPE_0", "funct6" -> [ 8; 9; 10; 11; 37; 39; 36; 38; 32; 33; 34; 35 ]
+  | Ident "MVXMATYPE_0", "funct6" -> [ 45; 47; 41; 43 ]
+  | Ident "MVXTYPE_0", "funct6" -> [ 8; 9; 10; 11; 14; 15; 37; 39; 36; 38; 32; 33; 34; 35 ]
+  | Ident "NISTYPE_0", "funct6" -> [ 44; 45 ]
+  | Ident "NITYPE_0", "funct6" -> [ 46; 47 ]
+  | Ident "NVSTYPE_0", "funct6" -> [ 44; 45 ]
+  | Ident "NVTYPE_0", "funct6" -> [ 46; 47 ]
+  | Ident "NXSTYPE_0", "funct6" -> [ 44; 45 ]
+  | Ident "NXTYPE_0", "funct6" -> [ 46; 47 ]
+  | Ident "REM_0", "is_unsigned" -> [ 1; 0 ]
+  | Ident "REMW_0", "is_unsigned" -> [ 1; 0 ]
+  | Ident "RFVVTYPE_0", "funct6" -> [ 3; 1; 7; 5; 51; 49 ]
+  | Ident "RIVVTYPE_0", "funct6" -> [ 48; 49 ]
+  | Ident "RMVVTYPE_0", "funct6" -> [ 0; 1; 2; 3; 4; 5; 6; 7 ]
+  | Ident "UTYPE_0", "op" -> [ 55; 23 ]
+  | Ident "VAESDF_0", "funct6" -> [ 40; 41 ]
+  | Ident "VAESDM_0", "funct6" -> [ 40; 41 ]
+  | Ident "VAESEF_0", "funct6" -> [ 40; 41 ]
+  | Ident "VAESEM_0", "funct6" -> [ 40; 41 ]
+  | Ident "VEXT2TYPE_0", "funct6" -> [ 6; 7 ]
+  | Ident "VEXT4TYPE_0", "funct6" -> [ 4; 5 ]
+  | Ident "VEXT8TYPE_0", "funct6" -> [ 2; 3 ]
+  | Ident "VFNUNARY0_0", "vfnunary0XN" -> [ 16; 17; 18; 19; 20; 21; 22; 23 ]
+  | Ident "VFUNARY0_0", "vfunary0XN" -> [ 0; 1; 2; 3; 6; 7 ]
+  | Ident "VFUNARY1_0", "vfunary1XN" -> [ 0; 4; 5; 16 ]
+  | Ident "VFWUNARY0_0", "vfwunary0XN" -> [ 8; 9; 10; 11; 12; 14; 15 ]
+  | Ident "VICMPTYPE_0", "funct6" -> [ 24; 25; 28; 29; 30; 31 ]
+  | Ident "VIMCTYPE_0", "funct6" -> [ 17 ]
+  | Ident "VIMSTYPE_0", "funct6" -> [ 16 ]
+  | Ident "VIMTYPE_0", "funct6" -> [ 17 ]
+  | Ident "VISG_0", "funct6" -> [ 14; 15; 12 ]
+  | Ident "VITYPE_0", "funct6" -> [ 0; 3; 9; 10; 11; 32; 33; 37; 40; 41; 42; 43 ]
+  | Ident "VLOXSEGTYPE_0", "width" -> [ 0; 5; 6; 7 ]
+  | Ident "VLRETYPE_0", "width" -> [ 0; 5; 6; 7 ]
+  | Ident "VLSEGFFTYPE_0", "width" -> [ 0; 5; 6; 7 ]
+  | Ident "VLSEGTYPE_0", "width" -> [ 0; 5; 6; 7 ]
+  | Ident "VLSSEGTYPE_0", "width" -> [ 0; 5; 6; 7 ]
+  | Ident "VLUXSEGTYPE_0", "width" -> [ 0; 5; 6; 7 ]
+  | Ident "VMTYPE_0", "op" -> [ 7; 39 ]
+  | Ident "VSOXSEGTYPE_0", "width" -> [ 0; 5; 6; 7 ]
+  | Ident "VSSEGTYPE_0", "width" -> [ 0; 5; 6; 7 ]
+  | Ident "VSSSEGTYPE_0", "width" -> [ 0; 5; 6; 7 ]
+  | Ident "VSUXSEGTYPE_0", "width" -> [ 0; 5; 6; 7 ]
+  | Ident "VVCMPTYPE_0", "funct6" -> [ 24; 25; 26; 27; 28; 29 ]
+  | Ident "VVMCTYPE_0", "funct6" -> [ 17; 19 ]
+  | Ident "VVMSTYPE_0", "funct6" -> [ 16; 18 ]
+  | Ident "VVMTYPE_0", "funct6" -> [ 17; 19 ]
+  | Ident "VVTYPE_0", "funct6" -> [ 0; 2; 4; 5; 6; 7; 9; 10; 11; 12; 14; 32; 33; 34; 35; 37; 39; 40; 41; 42; 43 ]
+  | Ident "VXCMPTYPE_0", "funct6" -> [ 24; 25; 26; 27; 28; 29; 30; 31 ]
+  | Ident "VXMCTYPE_0", "funct6" -> [ 17; 19 ]
+  | Ident "VXMSTYPE_0", "funct6" -> [ 16; 18 ]
+  | Ident "VXMTYPE_0", "funct6" -> [ 17; 19 ]
+  | Ident "VXSG_0", "funct6" -> [ 14; 15; 12 ]
+  | Ident "VXTYPE_0", "funct6" -> [ 0; 2; 3; 4; 5; 6; 7; 9; 10; 11; 32; 33; 34; 35; 37; 39; 40; 41; 42; 43 ]
+  | Ident "WMVVTYPE_0", "funct6" -> [ 60; 61; 63 ]
+  | Ident "WMVXTYPE_0", "funct6" -> [ 60; 61; 62; 63 ]
+  | Ident "WRS_0", "op" -> [ 29; 13 ]
+  | Ident "WVTYPE_0", "funct6" -> [ 53; 55; 52; 54 ]
+  | Ident "WVVTYPE_0", "funct6" -> [ 49; 51; 48; 50; 59; 56; 58 ]
+  | Ident "WVXTYPE_0", "funct6" -> [ 49; 51; 48; 50; 59; 56; 58 ]
+  | Ident "WXTYPE_0", "funct6" -> [ 53; 55; 52; 54 ]
+  | Ident "ZICBOM_0", "cbop" -> [ 1; 2; 0 ]
+  | Ident "ZVKSHA2TYPE_0", "funct6" -> [ 46; 47 ]
+
   | _ -> List.init (min 256 bound) (fun x -> x)
 
 let enumerate_encoding (enc: encoding) (field_vals: string -> int -> int list): encoding_tree =
@@ -452,11 +553,12 @@ let get_opcodes (opt_verbose: bool ref) (iset: string) (instr: string) (env: Env
 
   List.fold_left (fun encs enc ->
       let Encoding_Block (nm,_,fields,_,_,_,_,_) = enc in
+      if !opt_verbose then Printf.printf "Coverage for encoding block %s\n%!" (pprint_ident nm);
       let newEnc = pprint_ident nm in
       let t = enumerate_encoding enc (field_vals_flags_only enc) in
       let l = list_of_enc_tree t in
       let opcodes = (match get_opcodes nm with
-      | [||] -> 
+      | [||] ->
         None
       | ops ->
           Some (List.fold_left (fun codes op ->

--- a/libASL/transforms.ml
+++ b/libASL/transforms.ml
@@ -421,6 +421,10 @@ module StatefulIntToBits = struct
         let y = force_signed (bv_of_int_expr st y) in
         assert (is_pos x = is_pos y);
         build_div x y
+    | Expr_TApply (FIdent ("zdiv_int", 0), [], [x; y]) ->
+        let x = force_signed (bv_of_int_expr st x) in
+        let y = force_signed (bv_of_int_expr st y) in
+        build_div x y
 
     (* when the divisor is a power of 2, mod can be implemented by truncating. *)
     | Expr_TApply (FIdent ("frem_int", 0), [], [n;Expr_LitInt d]) when is_power_of_2 (int_of_string d) ->
@@ -1461,6 +1465,7 @@ module CommonSubExprElim = struct
       | Stmt_ConstDecl(_, n, _, _) ->
           consts <- IdentSet.add n consts;
           SkipChildren
+      | Stmt_If _ -> SkipChildren
       | _ -> DoChildren)
     method get_info = consts
   end

--- a/libASL/transforms.ml
+++ b/libASL/transforms.ml
@@ -1835,7 +1835,7 @@ module type ScopedBindings = sig
     val add_bind : 'elt t  -> ident -> 'elt -> unit
     val find_binding : 'elt t -> ident -> 'elt option
     val current_scope_bindings : 'elt t -> 'elt Bindings.t
-    val init: unit -> 'elt t  
+    val init: unit -> 'elt t
 end
 
 module ScopedBindings : ScopedBindings = struct
@@ -2187,7 +2187,7 @@ end
 module BDDSimp = struct
   let log = false
 
-  type abs = 
+  type abs =
     Top |
     Val of MLBDD.t list |
     Bot
@@ -2201,9 +2201,9 @@ module BDDSimp = struct
 
   module type Lattice = RTAnalysisLattice with type olt = state
 
-  module NopAnalysis = struct  
+  module NopAnalysis = struct
     type rt = unit
-    type olt = state 
+    type olt = state
     let xfer_stmt o r s = r,[s]
     let join o c j r ro = ()
     let init _ = ()
@@ -2214,7 +2214,7 @@ module BDDSimp = struct
     man = MLBDD.manager ctx;
     vars = Bindings.empty ;
     ctx ;
-    stmts = [] 
+    stmts = []
   }
 
 
@@ -2267,7 +2267,7 @@ module BDDSimp = struct
 
   let to_bool abs st =
     match abs with
-    | Top 
+    | Top
     | Bot -> MLBDD.dtrue st.man
     | Val [v] -> v
     | _ -> failwith "unexpected to_bool"
@@ -2302,7 +2302,7 @@ module BDDSimp = struct
 
   let wrap_bop f a b =
     match a, b with
-    | Bot, _ 
+    | Bot, _
     | _, Bot -> Bot
     | Top, _
     | _, Top -> Top
@@ -2384,72 +2384,72 @@ module BDDSimp = struct
     match e with
     | Top -> Top
     | Bot -> Bot
-    | Val v -> 
+    | Val v ->
         let start = List.length v - lo - wd in
         Val (sublist v start wd)
 
 
-  let half_add_bit l r = MLBDD.dand l r, MLBDD.xor l r  (* carry, sum *) 
-  let full_add_bit l r carry = 
+  let half_add_bit l r = MLBDD.dand l r, MLBDD.xor l r  (* carry, sum *)
+  let full_add_bit l r carry =
     let c1,s1 = half_add_bit l r in
     let c2,o = half_add_bit s1 carry in
     let ocarry = MLBDD.dor c1 c2 in
     ocarry,o
 
-  let twos_comp_add (xs : MLBDD.t list) (ys: MLBDD.t list) : MLBDD.t * (MLBDD.t list)= 
+  let twos_comp_add (xs : MLBDD.t list) (ys: MLBDD.t list) : MLBDD.t * (MLBDD.t list)=
       let xs = List.rev xs in let ys = List.rev ys in
-      match xs,ys with 
-        | hx::tlx,hy::tly ->  
+      match xs,ys with
+        | hx::tlx,hy::tly ->
           let lscarry,lsb = half_add_bit hx hy in
           let bits,carry = List.fold_left2
-          (fun (acc,carry) (l:MLBDD.t) (r:MLBDD.t)  -> let carry,o = (full_add_bit l r carry) in o::acc , carry) 
+          (fun (acc,carry) (l:MLBDD.t) (r:MLBDD.t)  -> let carry,o = (full_add_bit l r carry) in o::acc , carry)
             ([lsb], lscarry) tlx tly
           in carry,bits
         | _,_ -> failwith "invalid bit strings"
 
   let signed_add_wrap x y = let _,bits = twos_comp_add x y in bits
 
-  
+
   let addone m xs  = let one = MLBDD.dtrue m in
       let xs = List.rev xs  in
-      let c,rs = match xs with 
-        | hx::tlx ->  
+      let c,rs = match xs with
+        | hx::tlx ->
           let lscarry,lsb = half_add_bit hx one in
           let bits,carry = List.fold_left
-            (fun (acc,carry) (l:MLBDD.t) -> let carry,o = (half_add_bit l carry) in o::acc, carry) 
+            (fun (acc,carry) (l:MLBDD.t) -> let carry,o = (half_add_bit l carry) in o::acc, carry)
             ([lsb], lscarry) tlx
           in carry,bits
         | _ -> failwith "no"
       in rs
-    
+
 
   let signed_negation m (x:MLBDD.t list) =  addone m (List.map MLBDD.dnot x)
 
   let signed_sub_wrap m x y = let _,bits = twos_comp_add x (signed_negation m y) in bits
 
 (*
-  let signed_lt m x y =  
+  let signed_lt m x y =
 
   let signed_gt m x y = List.map MLBDD.dnot (signed_lt m x y)
   *)
 
 
 
-  let eq_bvs a b = 
+  let eq_bvs a b =
     let bits = List.map2 MLBDD.eq a b in
     match bits with
       | x::xs -> List.fold_right MLBDD.dand xs x
       | _ -> failwith "bad bits width"
 
-    let sle_bits m x y = 
-      MLBDD.dor 
+    let sle_bits m x y =
+      MLBDD.dor
         (MLBDD.dand (List.hd x) (MLBDD.dnot (List.hd y)))
         (MLBDD.dnot (MLBDD.xor (List.hd x) (List.hd y)) )
 
   (* https://cs.nyu.edu/pipermail/smt-lib/2007/000182.html *)
 
   let unknown_prims = ref Bindings.empty
-  let print_unknown_prims (c:unit) = if log then (Bindings.to_seq !unknown_prims |> List.of_seq |> List.sort (fun a b -> compare (snd a) (snd b)) 
+  let print_unknown_prims (c:unit) = if log then (Bindings.to_seq !unknown_prims |> List.of_seq |> List.sort (fun a b -> compare (snd a) (snd b))
     |> List.iter (fun (id,c) -> Printf.printf "%d \t : %s\n" c (pprint_ident id)))
 
   let eq_bit a b = MLBDD.dnot (MLBDD.xor a b)
@@ -2461,23 +2461,23 @@ module BDDSimp = struct
       (MLBDD.dfalse m, MLBDD.dtrue m) (s) (t))
   in (MLBDD.dand a b)
 
-  let bvult m x y : MLBDD.t = bvugt m y x 
+  let bvult m x y : MLBDD.t = bvugt m y x
   let bvule m x y = MLBDD.dor (bvult m x y) (eq_bvs x y)
   let bvuge m x y = MLBDD.dor (bvugt m x y) (eq_bvs x y)
 
-  let bvslt m x y = MLBDD.dor 
+  let bvslt m x y = MLBDD.dor
     (MLBDD.dand (List.hd x) (MLBDD.dnot (List.hd y)))
     (MLBDD.dand (eq_bit (List.hd x) (List.hd y)) (bvult m x y))
 
   let bvsgt m x y = bvslt m y x
 
-  let bvsle m x y = MLBDD.dor 
+  let bvsle m x y = MLBDD.dor
     (MLBDD.dand (List.hd x) (MLBDD.dnot (List.hd y)))
     (MLBDD.dand (eq_bit (List.hd x) (List.hd y)) (bvule m x y))
 
-  let bvsge m x y = bvsle m y x 
+  let bvsge m x y = bvsle m y x
 
-  let wrap_bv_bool f m x y  =  match x , y with 
+  let wrap_bv_bool f m x y  =  match x , y with
       | Val x, Val y -> Val [(f m x y)]
       | _,_ -> Top
 
@@ -2488,7 +2488,7 @@ module BDDSimp = struct
 
   let twos_comp_sub man (xs : MLBDD.t list) (ys: MLBDD.t list) = ()
 
-  let replicate_bits newlen bits = match bits with 
+  let replicate_bits newlen bits = match bits with
     | Val bits -> if Int.rem newlen (List.length bits) <> 0 then failwith "indivisible rep length"  ;
       let repeats = newlen / (List.length bits) in Val (List.concat (List.init repeats (fun i -> bits)))
     | _ -> Top
@@ -2498,7 +2498,7 @@ module BDDSimp = struct
   (****************************************************************)
 
 
-  let eval_prim f tes es st = 
+  let eval_prim f tes es st =
     match f, tes, es with
     | "and_bool", [], [x; y] -> and_bool x y
     | "or_bool",  [], [x; y] -> or_bool x y
@@ -2520,20 +2520,20 @@ module BDDSimp = struct
         zero_extend_bits x (int_of_string nw) st
     | "SignExtend", [w;Expr_LitInt nw], [x; y] ->
         sign_extend_bits x (int_of_string nw) st
-      
-    | "add_bits", [Expr_LitInt w], [x; y] -> (match x,y with 
+
+    | "add_bits", [Expr_LitInt w], [x; y] -> (match x,y with
       | Val x, Val y -> let r = (signed_add_wrap x y) in assert (List.length r == (int_of_string w)); Val r
         | _,_ -> Top)
-    | "sub_bits", [w], [x; y] -> (match x,y with 
+    | "sub_bits", [w], [x; y] -> (match x,y with
         | Val x, Val y -> Val (signed_add_wrap x (signed_negation st.man y))
-        | _,_ -> Top) 
-        
-    | "ule_bits", [w], [x; y] -> wrap_bv_bool bvule st.man x y  
-    | "uge_bits", [w], [x; y] -> wrap_bv_bool bvuge st.man x y  
-    | "sle_bits", [w], [x; y] -> wrap_bv_bool bvsle st.man x y  
-    | "sge_bits", [w], [x; y] -> wrap_bv_bool bvsge st.man x y  
-    | "slt_bits", [w], [x; y] -> wrap_bv_bool bvslt st.man x y  
-    | "sgt_bits", [w], [x; y] -> wrap_bv_bool bvsgt st.man x y  
+        | _,_ -> Top)
+
+    | "ule_bits", [w], [x; y] -> wrap_bv_bool bvule st.man x y
+    | "uge_bits", [w], [x; y] -> wrap_bv_bool bvuge st.man x y
+    | "sle_bits", [w], [x; y] -> wrap_bv_bool bvsle st.man x y
+    | "sge_bits", [w], [x; y] -> wrap_bv_bool bvsge st.man x y
+    | "slt_bits", [w], [x; y] -> wrap_bv_bool bvslt st.man x y
+    | "sgt_bits", [w], [x; y] -> wrap_bv_bool bvsgt st.man x y
 
     (*
 
@@ -2543,8 +2543,8 @@ module BDDSimp = struct
     | "mul_bits", _, [x; y] -> Top
       *)
 
-    | _, _, _ -> 
-        unknown_prims  :=  (Bindings.find_opt (Ident f) !unknown_prims) |> (function Some x -> x + 1 | None -> 0) 
+    | _, _, _ ->
+        unknown_prims  :=  (Bindings.find_opt (Ident f) !unknown_prims) |> (function Some x -> x + 1 | None -> 0)
             |> (fun x -> Bindings.add (Ident f) x !unknown_prims) ;
         Top
 
@@ -2552,7 +2552,7 @@ module BDDSimp = struct
     match e with
     | Expr_Var (Ident "TRUE") -> Val ([ MLBDD.dtrue st.man ])
     | Expr_Var (Ident "FALSE") -> Val ([ MLBDD.dfalse st.man ])
-    | Expr_LitBits b -> 
+    | Expr_LitBits b ->
         Val (String.fold_right (fun c acc ->
           match c with
           | '1' -> (MLBDD.dtrue st.man)::acc
@@ -2585,7 +2585,7 @@ module BDDSimp = struct
     | Expr_LitString _ -> if log then Printf.printf "unexpected Expr_LitString %s" (pp_expr e); Top
     | Expr_If _ -> if log then Printf.printf "unexpected Expr_If %s" (pp_expr e); Top
 
-    | _ -> failwith @@ Printf.sprintf "BDDSimp eval_expr: unexpected expr: %s\n"  (pp_expr e)  
+    | _ -> failwith @@ Printf.sprintf "BDDSimp eval_expr: unexpected expr: %s\n"  (pp_expr e)
 
   (****************************************************************)
   (** Stmt Walk                                                   *)
@@ -2596,7 +2596,7 @@ module BDDSimp = struct
 
   let ctx_to_mask c =
     let imps = MLBDD.allprime c in
-    match imps with 
+    match imps with
     | x::xs -> List.fold_right join_imps xs x
     | _ -> invalid_arg "ctx_to_mask"
 
@@ -2608,7 +2608,7 @@ module BDDSimp = struct
 
 
   let bdd_to_expr cond st =
-    let bd_to_test b = 
+    let bd_to_test b =
         let bv = Value.to_mask Unknown (Value.from_maskLit b) in
         sym_expr @@ sym_inmask Unknown (Exp (Expr_Var (Ident "enc"))) bv
       in
@@ -2637,18 +2637,18 @@ module BDDSimp = struct
           )
     | _ -> None
 
-  let rebuild_expr e cond st = match bdd_to_expr cond st with 
+  let rebuild_expr e cond st = match bdd_to_expr cond st with
       | Some x -> x
       | None -> if log then Printf.printf "Unable to simplify expr" ; e
 
 
-  class nopvis = object(self) 
+  class nopvis = object(self)
     method xf_stmt (x:stmt) (st:state) : stmt list = [x]
   end
 
   let nop_transform = new nopvis
 
-  module EvalWithXfer (Xf: Lattice) = struct 
+  module EvalWithXfer (Xf: Lattice) = struct
 
   let rec eval_stmt (xs:Xf.rt) (s:stmt) (st:state) =
       (* (transfer : xs, s, st ->  xs', s' ; eval : st -> s -> st' ; write s' : s' , st' -> st'' ) -> xs' s' st''  *)
@@ -2680,7 +2680,7 @@ module BDDSimp = struct
           restrict_ctx abs st, xs
 
     (* State becomes bot - unreachable *)
-    | Stmt_Throw _ -> 
+    | Stmt_Throw _ ->
         if log then Printf.printf "%s : %s\n" (pp_stmt s) (pp_state st);
         let st = writeall ns st in
         halt st,xs
@@ -2689,7 +2689,7 @@ module BDDSimp = struct
     | Stmt_If(c, tstmts, [], fstmts, loc) ->
         let cond = eval_expr c st in
 
-        if is_true cond st then  
+        if is_true cond st then
           eval_stmts xs tstmts st
         else if is_false cond st then
           eval_stmts xs fstmts st
@@ -2708,7 +2708,7 @@ module BDDSimp = struct
 
     (* Can't do anything here *)
     | Stmt_Assign _
-    | Stmt_TCall _ -> 
+    | Stmt_TCall _ ->
         writeall ns st,xs
 
     | _ -> failwith "unknown stmt"
@@ -2722,7 +2722,7 @@ module BDDSimp = struct
     let enc = Val (List.rev (List.init 32 (MLBDD.ithvar st.man))) in
     {st with vars = Bindings.add (Ident "enc") enc st.vars}
 
-  module Eval = EvalWithXfer(NopAnalysis) 
+  module Eval = EvalWithXfer(NopAnalysis)
 
   let just_eval a b c = fst (Eval.eval_stmts (NopAnalysis.init ()) a b)
 
@@ -2782,7 +2782,7 @@ module BDDSimp = struct
     Bindings.mapi (fun nm fnsig ->
       let i = match nm with FIdent(s,_) -> Ident s | s -> s in
       match Bindings.find_opt i st.instrs with
-      | Some reach -> fnsig_upd_body (fun b -> 
+      | Some reach -> fnsig_upd_body (fun b ->
         if log then Printf.printf "transforming %s\n" (pprint_ident nm);
         do_transform nm b reach) fnsig
       | None -> fnsig) instrs

--- a/libASL/value.ml
+++ b/libASL/value.ml
@@ -344,6 +344,7 @@ let eval_prim (f: string) (tvs: value list) (vs: value list): value option =
 
     (* The remaining primops all have side effects *)
     | ("ram_init",          _,        [VInt a; VInt n; VRAM ram; VBits i])          -> Some (prim_init_ram a n ram i; VTuple [])
+    | ("ram_init",          _,        [VInt a; VInt n; VUninitialized _; VBits i])  -> Some (prim_init_ram a n (Primops.init_ram (char_of_int 0)) i; VTuple [])
     | ("ram_read",          _,        [VInt a; VInt n; VRAM ram; VBits i])          -> Some (VBits (prim_read_ram a n ram i.v))
     | ("ram_write",         _,        [VInt a; VInt n; VRAM ram; VBits i; VBits x]) -> Some (prim_write_ram a n ram i.v x; VTuple [])
 

--- a/libASL/value.ml
+++ b/libASL/value.ml
@@ -324,6 +324,7 @@ let eval_prim (f: string) (tvs: value list) (vs: value list): value option =
     | ("not_bits",          [VInt n], [VBits x             ])     -> Some (VBits   (prim_not_bits x))
     | ("zeros_bits",        [VInt n], [                    ])     -> Some (VBits   (prim_zeros_bits n))
     | ("ones_bits",         [VInt n], [                    ])     -> Some (VBits   (prim_ones_bits n))
+    | ("random_bits",       [VInt n], [                    ])     -> Some (VBits   (Primops.({n = Z.to_int n; v = Z.random_bits (Z.to_int n)})))
     | ("replicate_bits",    [_; _  ], [VBits x; VInt y     ])     -> Some (VBits   (prim_replicate_bits x y))
     | ("append_bits",       [VInt m; VInt n], [VBits x; VBits y]) -> Some (VBits   (prim_append_bits x y))
     | ("eq_str",            [      ], [VString x; VString y])     -> Some (VBool   (prim_eq_str x y))

--- a/prelude.asl
+++ b/prelude.asl
@@ -81,6 +81,7 @@ __builtin bits(N)   eor_bits(bits(N) x, bits(N) y);
 __builtin bits(N)   not_bits(bits(N) x);
 __builtin bits(N)   zeros_bits();
 __builtin bits(N)   ones_bits();
+__builtin bits(N)   random_bits();
 __builtin boolean   cvt_bv_bool(bit x);
 __builtin bit       cvt_bool_bv(boolean x);
 

--- a/tests/override.asl
+++ b/tests/override.asl
@@ -579,3 +579,15 @@ bits(N) FPToFixedJS_impl(bits(M) op, FPCRType fpcr, boolean Is64)
 (bits(N), bit) FPToFixedJS(bits(M) op, FPCRType fpcr, boolean Is64)
     bits(N + 1) res = FPToFixedJS_impl(op, fpcr, Is64);
     return (res[N:1], res[0]);
+
+random_state()
+    // Initialize register array: 31 elements, each 64 bits wide
+    for i = 0 to 30
+        _R[i] = random_bits();
+
+    // Initialize vector array: 32 elements, each 128 bits wide
+    for i = 0 to 31
+        _Z[i] = random_bits();
+
+    // Initialize memory with random default
+    __InitRAM(52, 1, __Memory, Zeros(8));

--- a/tests/test_asl.ml
+++ b/tests/test_asl.ml
@@ -26,7 +26,8 @@ let mra_tools () = List.map (fun x -> LoadASL.FileSource x) [
     "../../../mra_tools/support/interrupts.asl";
     "../../../mra_tools/support/memory.asl";
     "../../../mra_tools/support/stubs.asl";
-    "../../../mra_tools/support/fetchdecode.asl"
+    "../../../mra_tools/support/fetchdecode.asl";
+    "../../../tests/override.asl"
 ]
 
 let format_value f v = Format.fprintf f "%s" (Value.pp_value v)


### PR DESCRIPTION
We have a reasonable [RISC-V model](https://github.com/ncough/sail/tree/asl/asl_model) by translation from Sail. A few changes are necessary to get ASLi to accept these models though, as the Sail type system is more complex. Even with these changes, there are a number of functions that do not type check due to a reliance on if-statement guards to prove type correctness.

Changes include:
* Not assuming `PSTATE`, etc. exists in the model.
* More robust Z3 translation, including `Expr_If`, `pow2_int`, and more (unsound) heuristics around `fdiv_int`.
* Including the conditions on `Stmt_Assert` when reasoning over types.
* Substituting global constants in type constraints.