### PR TITLE
deparametrise unconstrained types in offline ocaml IBI 

### DIFF
--- a/aslp_offline.opam
+++ b/aslp_offline.opam
@@ -12,7 +12,6 @@ depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.14"}
   "odoc" {with-doc}
-  "menhir" {>= "20180523"}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/libASL/ocaml_backend.ml
+++ b/libASL/ocaml_backend.ml
@@ -90,13 +90,11 @@ let write_asl_runner_epilogue use_pc fid st =
   in
   let pc_arg = if use_pc then " ~(pc:int)" else "" in
   Printf.fprintf st.oc {|let run %s enc =
-  let module I =
-    (Asl_ibi : Instruction_building_interface.IBI
-      with type bitvector = LibASL_stage0.Primops.bitvector
-      and type ast = LibASL_stage0.Asl_ast.stmt list) in
-  I.reset_ir ();
+  let module I = Asl_ibi in
+  Asl_ibi.reset_ir ();
   %s;
-  I.get_ir ()|} pc_arg dis_call
+  Asl_ibi.get_ir ()
+|} pc_arg dis_call
 
 let write_line s st =
   let padding = String.concat "" (List.init st.depth (fun _ -> " ")) in

--- a/offlineASL/template_instruction_building_interface.ml
+++ b/offlineASL/template_instruction_building_interface.ml
@@ -69,46 +69,46 @@ module type IBI = sig
 
   val f_sdiv_int : bigint -> bigint -> bigint
   val f_shl_int : bigint -> bigint -> bigint
-  val v_PSTATE_C : expr
-  val v_PSTATE_Z : expr
-  val v_PSTATE_V : expr
-  val v_PSTATE_N : expr
-  val v__PC : expr
-  val v__R : expr
-  val v__Z : expr
-  val v_SP_EL0 : expr
-  val v_FPSR : expr
-  val v_FPCR : expr
-  val v_PSTATE_A : expr
-  val v_PSTATE_D : expr
-  val v_PSTATE_DIT : expr
-  val v_PSTATE_F : expr
-  val v_PSTATE_I : expr
-  val v_PSTATE_PAN : expr
-  val v_PSTATE_SP : expr
-  val v_PSTATE_SSBS : expr
-  val v_PSTATE_TCO : expr
-  val v_PSTATE_UAO : expr
-  val v_PSTATE_BTYPE : expr
-  val v_BTypeCompatible : expr
-  val v___BranchTaken : expr
-  val v_BTypeNext : expr
-  val v___ExclusiveLocal : expr
+  val v_PSTATE_C : lexpr
+  val v_PSTATE_Z : lexpr
+  val v_PSTATE_V : lexpr
+  val v_PSTATE_N : lexpr
+  val v__PC : lexpr
+  val v__R : lexpr
+  val v__Z : lexpr
+  val v_SP_EL0 : lexpr
+  val v_FPSR : lexpr
+  val v_FPCR : lexpr
+  val v_PSTATE_A : lexpr
+  val v_PSTATE_D : lexpr
+  val v_PSTATE_DIT : lexpr
+  val v_PSTATE_F : lexpr
+  val v_PSTATE_I : lexpr
+  val v_PSTATE_PAN : lexpr
+  val v_PSTATE_SP : lexpr
+  val v_PSTATE_SSBS : lexpr
+  val v_PSTATE_TCO : lexpr
+  val v_PSTATE_UAO : lexpr
+  val v_PSTATE_BTYPE : lexpr
+  val v_BTypeCompatible : lexpr
+  val v___BranchTaken : lexpr
+  val v_BTypeNext : lexpr
+  val v___ExclusiveLocal : lexpr
   val f_switch_context : branch -> unit
   val f_gen_branch : expr -> branch * branch * branch
   val f_true_branch : branch * branch * branch -> branch
   val f_false_branch : branch * branch * branch -> branch
   val f_merge_branch : branch * branch * branch -> branch
   val f_gen_assert : expr -> unit
-  val f_gen_bit_lit : 'a -> bitvector -> expr
+  val f_gen_bit_lit : bigint -> bitvector -> expr
   val f_gen_bool_lit : bool -> expr
   val f_gen_int_lit : bigint -> expr
-  val f_decl_bv : string -> bigint -> expr
-  val f_decl_bool : string -> expr
-  val f_gen_load : 'a -> 'a
-  val f_gen_store : expr -> expr -> unit
-  val f_gen_array_load : expr -> bigint -> expr
-  val f_gen_array_store : expr -> bigint -> expr -> unit
+  val f_decl_bv : string -> bigint -> lexpr
+  val f_decl_bool : string -> lexpr
+  val f_gen_load : lexpr -> expr
+  val f_gen_store : lexpr -> expr -> unit
+  val f_gen_array_load : lexpr -> bigint -> expr
+  val f_gen_array_store : lexpr -> bigint -> expr -> unit
   val f_gen_Elem_read : bigint -> bigint -> expr -> expr -> expr -> expr
   val f_gen_Elem_set : bigint -> bigint -> expr -> expr -> expr -> expr -> expr
   val f_gen_Mem_set : bigint -> expr -> 'a -> expr -> expr -> unit

--- a/offlineASL/template_instruction_building_interface.ml
+++ b/offlineASL/template_instruction_building_interface.ml
@@ -120,8 +120,10 @@ module type IBI = sig
   val f_AtomicEnd : unit -> unit
   val f_gen_AArch64_MemTag_set : expr -> expr -> expr -> unit
   (** [f_gen_AArch64_MemTag_set address acctype value] *)
+
   val f_gen_AArch64_MemTag_read : expr -> expr -> expr
   (** [f_gen_AArch64_MemTag_read address acctype] *)
+
   val f_gen_and_bool : expr -> expr -> expr
   val f_gen_or_bool : expr -> expr -> expr
   val f_gen_not_bool : expr -> expr
@@ -145,10 +147,13 @@ module type IBI = sig
   val f_gen_asr_bits : bigint -> bigint -> expr -> expr -> expr
   val f_gen_replicate_bits : bigint -> bigint -> expr -> bigint -> expr
   (** [f_gen_replicate_bits operand_width num_replications operand num_replications] *)
+
   val f_gen_ZeroExtend : bigint -> bigint -> expr -> bigint -> expr
   (** [f_gen_ZeroExtend operand_width result_width operand result_width] *)
+
   val f_gen_SignExtend : bigint -> bigint -> expr -> bigint -> expr
   (** [f_gen_SignExtend operand_width result_width operand result_width] *)
+
   val f_gen_slice : expr -> bigint -> bigint -> expr
   val f_gen_FPCompare : bigint -> expr -> expr -> expr -> expr -> expr
   val f_gen_FPCompareEQ : bigint -> expr -> expr -> expr -> expr

--- a/offlineASL/template_instruction_building_interface.ml
+++ b/offlineASL/template_instruction_building_interface.ml
@@ -112,10 +112,12 @@ module type IBI = sig
   val f_gen_Elem_read : bigint -> bigint -> expr -> expr -> expr -> expr
   val f_gen_Elem_set : bigint -> bigint -> expr -> expr -> expr -> expr -> expr
 
-  val f_gen_Mem_set : bigint -> expr -> bigint -> expr -> expr -> unit
+  val f_gen_Mem_set : bigint -> expr -> expr -> expr -> expr -> unit
   (** [f_gen_Mem_set size address size acctype value] *)
 
-  val f_gen_Mem_read : bigint -> expr -> bigint -> expr -> expr
+  val f_gen_Mem_read : bigint -> expr -> expr -> expr -> expr
+  (** [f_gen_Mem_read size address size acctype value] *)
+
   val f_AtomicStart : unit -> unit
   val f_AtomicEnd : unit -> unit
   val f_gen_AArch64_MemTag_set : expr -> expr -> expr -> unit
@@ -145,13 +147,13 @@ module type IBI = sig
   val f_gen_lsr_bits : bigint -> bigint -> expr -> expr -> expr
   val f_gen_lsl_bits : bigint -> bigint -> expr -> expr -> expr
   val f_gen_asr_bits : bigint -> bigint -> expr -> expr -> expr
-  val f_gen_replicate_bits : bigint -> bigint -> expr -> bigint -> expr
+  val f_gen_replicate_bits : bigint -> bigint -> expr -> expr -> expr
   (** [f_gen_replicate_bits operand_width num_replications operand num_replications] *)
 
-  val f_gen_ZeroExtend : bigint -> bigint -> expr -> bigint -> expr
+  val f_gen_ZeroExtend : bigint -> bigint -> expr -> expr -> expr
   (** [f_gen_ZeroExtend operand_width result_width operand result_width] *)
 
-  val f_gen_SignExtend : bigint -> bigint -> expr -> bigint -> expr
+  val f_gen_SignExtend : bigint -> bigint -> expr -> expr -> expr
   (** [f_gen_SignExtend operand_width result_width operand result_width] *)
 
   val f_gen_slice : expr -> bigint -> bigint -> expr

--- a/offlineASL/template_instruction_building_interface.ml
+++ b/offlineASL/template_instruction_building_interface.ml
@@ -111,12 +111,17 @@ module type IBI = sig
   val f_gen_array_store : lexpr -> bigint -> expr -> unit
   val f_gen_Elem_read : bigint -> bigint -> expr -> expr -> expr -> expr
   val f_gen_Elem_set : bigint -> bigint -> expr -> expr -> expr -> expr -> expr
-  val f_gen_Mem_set : bigint -> expr -> 'a -> expr -> expr -> unit
-  val f_gen_Mem_read : bigint -> expr -> 'a -> expr -> expr
+
+  val f_gen_Mem_set : bigint -> expr -> bigint -> expr -> expr -> unit
+  (** [f_gen_Mem_set size address size acctype value] *)
+
+  val f_gen_Mem_read : bigint -> expr -> bigint -> expr -> expr
   val f_AtomicStart : unit -> unit
   val f_AtomicEnd : unit -> unit
-  val f_gen_AArch64_MemTag_set : 'a -> 'b -> 'c -> unit
-  val f_gen_AArch64_MemTag_read : 'a -> 'b -> 'c
+  val f_gen_AArch64_MemTag_set : expr -> expr -> expr -> unit
+  (** [f_gen_AArch64_MemTag_set address acctype value] *)
+  val f_gen_AArch64_MemTag_read : expr -> expr -> expr
+  (** [f_gen_AArch64_MemTag_read address acctype] *)
   val f_gen_and_bool : expr -> expr -> expr
   val f_gen_or_bool : expr -> expr -> expr
   val f_gen_not_bool : expr -> expr
@@ -138,9 +143,12 @@ module type IBI = sig
   val f_gen_lsr_bits : bigint -> bigint -> expr -> expr -> expr
   val f_gen_lsl_bits : bigint -> bigint -> expr -> expr -> expr
   val f_gen_asr_bits : bigint -> bigint -> expr -> expr -> expr
-  val f_gen_replicate_bits : bigint -> bigint -> expr -> 'a -> expr
-  val f_gen_ZeroExtend : bigint -> bigint -> expr -> 'a -> expr
-  val f_gen_SignExtend : bigint -> bigint -> expr -> 'a -> expr
+  val f_gen_replicate_bits : bigint -> bigint -> expr -> bigint -> expr
+  (** [f_gen_replicate_bits operand_width num_replications operand num_replications] *)
+  val f_gen_ZeroExtend : bigint -> bigint -> expr -> bigint -> expr
+  (** [f_gen_ZeroExtend operand_width result_width operand result_width] *)
+  val f_gen_SignExtend : bigint -> bigint -> expr -> bigint -> expr
+  (** [f_gen_SignExtend operand_width result_width operand result_width] *)
   val f_gen_slice : expr -> bigint -> bigint -> expr
   val f_gen_FPCompare : bigint -> expr -> expr -> expr -> expr -> expr
   val f_gen_FPCompareEQ : bigint -> expr -> expr -> expr -> expr

--- a/offlineASL/template_offline_utils.ml
+++ b/offlineASL/template_offline_utils.ml
@@ -6,7 +6,7 @@ open Primops
 type bigint = Primops.bigint
 type bitvector = Primops.bitvector
 type nonrec expr = expr
-type nonrec lexpr = lexpr
+type nonrec lexpr = expr
 type nonrec stmt = stmt
 type branch = int
 type ast = stmt list


### PR DESCRIPTION
the presence of generic parameters in the IBI signature places an
impossible burden on the implementors, requiring them to satisfy the
maximally polymorphic signature. obviously, this prevents them from using a
more concrete implementation.

these generic parameters arose because they were uncosntrained in the ASLp IBI because their values were ignored.

i also introduce uses of the `lexpr` type for variables and loads/stores. implementors may simply set `expr = lexpr` if their IR does not distinguish the two.